### PR TITLE
Fix upload file, add delete file method

### DIFF
--- a/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/multimodality/MultimodalityIT.java
+++ b/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/multimodality/MultimodalityIT.java
@@ -5,7 +5,6 @@ import static org.hamcrest.Matchers.*;
 
 import chat.giga.springai.GigaChatModel;
 import chat.giga.springai.autoconfigure.GigaChatAutoConfiguration;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.ai.chat.messages.UserMessage;
@@ -17,7 +16,6 @@ import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.util.MimeTypeUtils;
 
-@Disabled("Временно отключено из-за 500 ошибок")
 public class MultimodalityIT {
 
     ApplicationContextRunner contextRunner = new ApplicationContextRunner()

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
@@ -21,7 +21,6 @@ import org.springframework.ai.content.Media;
 import org.springframework.ai.model.ChatModelDescription;
 import org.springframework.ai.model.ModelOptionsUtils;
 import org.springframework.ai.retry.RetryUtils;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -158,15 +157,12 @@ public class GigaChatApi {
 
         MultipartBodyBuilder builder = new MultipartBodyBuilder();
 
-        builder.part("file", new ByteArrayResource(media.getDataAsByteArray()) {
-                    @Override
-                    public String getFilename() {
-                        return media.getName();
-                    }
-                })
-                .contentType(MediaType.valueOf(media.getMimeType().toString()));
+        builder.part("file", media.getDataAsByteArray())
+                .contentType(MediaType.valueOf(media.getMimeType().toString()))
+                .header("Content-Disposition", "form-data; name=\"file\"; filename=\"" + media.getName() + "\"");
 
-        builder.part("purpose", "general", MediaType.TEXT_PLAIN);
+        builder.part("purpose", "general", MediaType.TEXT_PLAIN)
+                .header("Content-Disposition", "form-data; name=\"purpose\"");
 
         return this.restClient
                 .post()
@@ -183,7 +179,6 @@ public class GigaChatApi {
                 .post()
                 .uri("/files/{fileId}/delete", fileId)
                 .header(HttpHeaders.USER_AGENT, USER_AGENT_SPRING_AI_GIGACHAT)
-                .contentType(MediaType.APPLICATION_JSON)
                 .retrieve()
                 .toEntity(DeleteFileResponse.class);
     }

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
@@ -9,6 +9,7 @@ import chat.giga.springai.api.chat.completion.CompletionRequest;
 import chat.giga.springai.api.chat.completion.CompletionResponse;
 import chat.giga.springai.api.chat.embedding.EmbeddingsRequest;
 import chat.giga.springai.api.chat.embedding.EmbeddingsResponse;
+import chat.giga.springai.api.chat.file.DeleteFileResponse;
 import chat.giga.springai.api.chat.file.UploadFileResponse;
 import chat.giga.springai.api.chat.models.ModelsResponse;
 import com.fasterxml.jackson.annotation.JsonValue;
@@ -163,8 +164,7 @@ public class GigaChatApi {
                         return media.getName();
                     }
                 })
-                .contentType(MediaType.valueOf(media.getMimeType().toString()))
-                .header("Content-Disposition", "form-data; name=file; filename=" + media.getName());
+                .contentType(MediaType.valueOf(media.getMimeType().toString()));
 
         builder.part("purpose", "general", MediaType.TEXT_PLAIN);
 
@@ -176,6 +176,16 @@ public class GigaChatApi {
                 .body(builder.build())
                 .retrieve()
                 .toEntity(UploadFileResponse.class);
+    }
+
+    public ResponseEntity<DeleteFileResponse> deleteFile(String fileId) {
+        return this.restClient
+                .post()
+                .uri("/files/{fileId}/delete", fileId)
+                .header(HttpHeaders.USER_AGENT, USER_AGENT_SPRING_AI_GIGACHAT)
+                .contentType(MediaType.APPLICATION_JSON)
+                .retrieve()
+                .toEntity(DeleteFileResponse.class);
     }
 
     public ResponseEntity<ModelsResponse> models() {

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/file/DeleteFileResponse.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/file/DeleteFileResponse.java
@@ -1,0 +1,17 @@
+package chat.giga.springai.api.chat.file;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.UUID;
+
+public record DeleteFileResponse(
+        // Идентификатор файла.
+        UUID id,
+
+        // Признак удаления файла.
+        boolean deleted,
+
+        /*
+         * Доступность файла
+         * Возможные значения: public, private
+         * */
+        @JsonProperty("access_policy") String accessPolicy) {}


### PR DESCRIPTION
удаление хедера "Content-Disposition" в запросе на загрузку файла лечит проблему с загрузкой 

добавил метод для удаления файла. как встроить его непосредственно в chatClient разобраться не смог, к сожалению, но в будущем явно пригодится.