### PR TITLE
Добавлено сканирование зависимостей при сборке через ossindex-maven-p…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -252,6 +252,24 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+
+            <plugin>
+                <groupId>org.sonatype.ossindex.maven</groupId>
+                <artifactId>ossindex-maven-plugin</artifactId>
+                <version>3.2.0</version>
+                <configuration>
+                    <fail>false</fail>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>audit-dependencies</id>
+                        <phase>verify</phase>
+                        <goals>
+                            <goal>audit-aggregate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Добавлено сканирование зависимостей при сборке через ossindex-maven-plugin

Closes #8

На данный момент замечены:
```log
[WARNING] Detected 3 vulnerable components:
  org.springframework:spring-context:jar:6.2.6:test; https://ossindex.sonatype.org/component/pkg:maven/org.springframework/spring-context@6.2.6?utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
    * [CVE-2025-22233] CWE-20: Improper Input Validation (2.3); https://ossindex.sonatype.org/vulnerability/CVE-2025-22233?component-type=maven&component-name=org.springframework%2Fspring-context&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
  org.apache.tomcat.embed:tomcat-embed-core:jar:10.1.40:test; https://ossindex.sonatype.org/component/pkg:maven/org.apache.tomcat.embed/tomcat-embed-core@10.1.40?utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
    * [CVE-2025-48988] CWE-770: Allocation of Resources Without Limits or Throttling (8.7); https://ossindex.sonatype.org/vulnerability/CVE-2025-48988?component-type=maven&component-name=org.apache.tomcat.embed%2Ftomcat-embed-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
    * [CVE-2025-49125] CWE-288: Authentication Bypass Using an Alternate Path or Channel (6.3); https://ossindex.sonatype.org/vulnerability/CVE-2025-49125?component-type=maven&component-name=org.apache.tomcat.embed%2Ftomcat-embed-core&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
  org.springframework:spring-web:jar:6.2.6:compile; https://ossindex.sonatype.org/component/pkg:maven/org.springframework/spring-web@6.2.6?utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
    * [CVE-2025-41234] CWE-113: Improper Neutralization of CRLF Sequences in HTTP Headers ('HTTP Response Splitting') (7.4); https://ossindex.sonatype.org/vulnerability/CVE-2025-41234?component-type=maven&component-name=org.springframework%2Fspring-web&utm_source=ossindex-client&utm_medium=integration&utm_content=1.8.1
```

Ожидаемо, часть поправится с переходом на spring-boot 3.5.0