### PR TITLE
Доступ к id загруженных файлов + Исправление сохранения внутренних сообщений Spring AI в ChatResponseMetadata

### DIFF
--- a/docs/response-metadata.md
+++ b/docs/response-metadata.md
@@ -3,12 +3,12 @@
 Для получения дополнительной информации об ответе создан утилитный класс
 [GigaChatResponseUtils](../spring-ai-gigachat/src/main/java/chat/giga/springai/support/GigaChatResponseUtils.java)
 
-### Получение всей истории переписки с GigaChat
+### Получение всей переписки с GigaChat под капотом Spring AI
 
 Если Вам необходимо получить информацию обо всех сообщениях,
 которые были получены и отправлены под капотом фреймфорка Spring AI
 (например - какие тулы были вызваны, с какими параметрами, каковы результаты вызова тулов),
-можно воспользоваться утилитным методом `GigaChatResponseUtils.getConversationHistory(chatResponse)`.
+можно воспользоваться утилитным методом `GigaChatResponseUtils.getInternalMessages(chatResponse)`.
 
 Пример:
 
@@ -18,10 +18,40 @@ ChatResponse chatResponse = chatClient
         .toolCallbacks(GigaTools.from(new WeatherTools()))
         .call()
         .chatResponse();
-List<Message> toolResponseMessages = GigaChatResponseUtils.getConversationHistory(chatResponse)
+List<Message> toolResponseMessages = GigaChatResponseUtils.getInternalMessages(chatResponse)
         .stream()
         .filter(msg -> MessageType.TOOL.equals(msg.getMessageType()))
         .toList();
 log.info("Было вызвано {} функций", toolResponseMessages.size());
+```
+
+### Получение иденификаторов загруженных файлов при использовании Multimodality
+
+Если Вам необходимо получить идентификаторы загруженных файлов,
+(например - чтобы затем повторно использовать их в запросе или наоборот удалить),
+можно воспользоваться утилитным методом `GigaChatResponseUtils.getUploadedMediaIds(chatResponse)`.
+
+Пример:
+
+```java
+ChatResponse chatResponse = chatClient
+        .prompt()
+        .user(u -> u.text("Какая порода кота на фото?")
+                .media(new Media(MimeType.valueOf(multipartFile.getContentType()), multipartFile.getResource())))
+        .call()
+        .chatResponse();
+
+String mediaId = GigaChatResponseUtils.getUploadedMediaIds(chatResponse).get(0);
+
+// переиспользуем загруженные файлы в последующем запросе
+chatClient.prompt()
+        .user(u -> u.text("Какого цвета шерсть у кота на фото?")
+                // при повторном использовании mimeType и data не важны, но не должны быть null
+                .media(Media.builder().id(mediaId).mimeType(MediaType.ALL).data("").build()))
+        .call()
+        .chatResponse();
+
+// удаляем файлы
+uploadedMediaIds.forEach(gigaChatApi::deleteFile);
 ```
 

--- a/spring-ai-gigachat-example/src/main/java/chat/giga/springai/example/WeatherToolController.java
+++ b/spring-ai-gigachat-example/src/main/java/chat/giga/springai/example/WeatherToolController.java
@@ -162,7 +162,7 @@ public class WeatherToolController {
                 .toolCallbacks(GigaTools.from(new WeatherTools()))
                 .call()
                 .chatResponse();
-        List<Message> toolResponseMessages = GigaChatResponseUtils.getConversationHistory(chatResponse).stream()
+        List<Message> toolResponseMessages = GigaChatResponseUtils.getInternalMessages(chatResponse).stream()
                 .filter(msg -> MessageType.TOOL.equals(msg.getMessageType()))
                 .toList();
         log.info("Было вызвано {} функций", toolResponseMessages.size());

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/support/GigaChatResponseUtils.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/support/GigaChatResponseUtils.java
@@ -15,11 +15,19 @@ import org.springframework.ai.chat.model.ChatResponse;
 @UtilityClass
 @Slf4j
 public class GigaChatResponseUtils {
-    public static List<Message> getConversationHistory(ChatResponse chatResponse) {
+    public static List<Message> getInternalMessages(ChatResponse chatResponse) {
+        return getFromMetadata(chatResponse, GigaChatModel.INTERNAL_CONVERSATION_HISTORY, List.of());
+    }
+
+    public static List<String> getUploadedMediaIds(ChatResponse chatResponse) {
+        return getFromMetadata(chatResponse, GigaChatModel.UPLOADED_MEDIA_IDS, List.of());
+    }
+
+    private static <T> T getFromMetadata(ChatResponse chatResponse, String key, T defaultValue) {
         if (chatResponse != null && chatResponse.getMetadata() != null) {
-            List<Message> messages = chatResponse.getMetadata().get(GigaChatModel.CONVERSATION_HISTORY);
-            return messages == null ? List.of() : messages;
+            T data = chatResponse.getMetadata().get(key);
+            return data == null ? defaultValue : data;
         }
-        return List.of();
+        return defaultValue;
     }
 }

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/support/GigaChatResponseUtilsTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/support/GigaChatResponseUtilsTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.when;
 import chat.giga.springai.GigaChatModel;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -22,34 +24,66 @@ public class GigaChatResponseUtilsTest {
     private ChatResponse chatResponse;
 
     @Test
-    public void testGetConversationHistoryWithNullChatResponse() {
-        List<Message> result = GigaChatResponseUtils.getConversationHistory(null);
+    public void testGetInternalMessagesWithNullChatResponse() {
+        var result = GigaChatResponseUtils.getInternalMessages(null);
         assertEquals(Collections.emptyList(), result);
     }
 
     @Test
-    public void testGetConversationHistoryWithNullMetadata() {
+    public void testGetInternalMessagesWithNullMetadata() {
         when(chatResponse.getMetadata()).thenReturn(null);
-        List<Message> result = GigaChatResponseUtils.getConversationHistory(chatResponse);
+        var result = GigaChatResponseUtils.getInternalMessages(chatResponse);
         assertEquals(Collections.emptyList(), result);
     }
 
     @Test
-    public void testGetConversationHistoryWithEmptyMetadata() {
+    public void testGetInternalMessagesWithEmptyMetadata() {
         when(chatResponse.getMetadata())
                 .thenReturn(ChatResponseMetadata.builder().build());
-        List<Message> result = GigaChatResponseUtils.getConversationHistory(chatResponse);
+        var result = GigaChatResponseUtils.getInternalMessages(chatResponse);
         assertEquals(Collections.emptyList(), result);
     }
 
     @Test
-    public void testGetConversationHistoryWithConversationHistoryInMetadata() {
+    public void testGetInternalMessages() {
         Message message = new UserMessage("Hello, world!");
         var metadata = ChatResponseMetadata.builder()
-                .keyValue(GigaChatModel.CONVERSATION_HISTORY, List.of(message))
+                .keyValue(GigaChatModel.INTERNAL_CONVERSATION_HISTORY, List.of(message))
                 .build();
         when(chatResponse.getMetadata()).thenReturn(metadata);
-        List<Message> result = GigaChatResponseUtils.getConversationHistory(chatResponse);
+        var result = GigaChatResponseUtils.getInternalMessages(chatResponse);
         assertEquals(Collections.singletonList(message), result);
+    }
+
+    @Test
+    public void testGetUploadedMediaIdsWithNullChatResponse() {
+        var result = GigaChatResponseUtils.getUploadedMediaIds(null);
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    public void testGetUploadedMediaIdsWithNullMetadata() {
+        when(chatResponse.getMetadata()).thenReturn(null);
+        var result = GigaChatResponseUtils.getUploadedMediaIds(chatResponse);
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    public void testGetUploadedMediaIdsWithEmptyMetadata() {
+        when(chatResponse.getMetadata())
+                .thenReturn(ChatResponseMetadata.builder().build());
+        var result = GigaChatResponseUtils.getUploadedMediaIds(chatResponse);
+        assertEquals(Collections.emptyList(), result);
+    }
+
+    @Test
+    public void testGetUploadedMediaIds() {
+        String mediaId = UUID.randomUUID().toString();
+        var metadata = ChatResponseMetadata.builder()
+                .keyValue(GigaChatModel.UPLOADED_MEDIA_IDS, List.of(mediaId))
+                .build();
+        when(chatResponse.getMetadata()).thenReturn(metadata);
+        var result = GigaChatResponseUtils.getUploadedMediaIds(chatResponse);
+        assertEquals(Collections.singletonList(mediaId), result);
     }
 }

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/support/GigaChatResponseUtilsTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/support/GigaChatResponseUtilsTest.java
@@ -7,7 +7,6 @@ import chat.giga.springai.GigaChatModel;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
-
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;


### PR DESCRIPTION
* Сохранение id загруженных файлов в ChatResponseMetadata - Closes #4 
* Исправление сохранения внутренних сообщений Spring AI в ChatResponseMetadata - Fixes #12 - раньше могла быть доступна вся история сообщений из ChatMemory


