### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <aspectj.version>1.9.24</aspectj.version>
         <spring-boot.version>3.5.5</spring-boot.version>
         <spring-ai.version>1.0.1</spring-ai.version>
-        <sslcontext-kickstart>9.1.0</sslcontext-kickstart>
+        <ayza.version>10.0.0</ayza.version>
         <lombok.version>1.18.38</lombok.version>
         <wiremock-spring-boot.version>3.10.6</wiremock-spring-boot.version>
 
@@ -108,8 +108,8 @@
             </dependency>
             <dependency>
                 <groupId>io.github.hakky54</groupId>
-                <artifactId>sslcontext-kickstart-for-pem</artifactId>
-                <version>${sslcontext-kickstart}</version>
+                <artifactId>ayza-for-pem</artifactId>
+                <version>${ayza.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.wiremock.integrations</groupId>

--- a/spring-ai-gigachat/pom.xml
+++ b/spring-ai-gigachat/pom.xml
@@ -19,7 +19,7 @@
     <dependencies>
         <dependency>
             <groupId>io.github.hakky54</groupId>
-            <artifactId>sslcontext-kickstart-for-pem</artifactId>
+            <artifactId>ayza-for-pem</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.ai</groupId>


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to [ayza](https://github.com/Hakky54/ayza). The latest version is 10.0.0

Sorry for the inconvenience