### PR TITLE
Add JavaDoc to GigaChatModel class

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
@@ -45,8 +45,17 @@ import reactor.core.publisher.Flux;
  * Implementation of Spring AI {@link ChatModel} for GigaChat API.
  * Supports both synchronous and streaming chat completions.
  *
+ * <p>Features:</p>
+ * <ul>
+ *   <li>Blocking and streaming chat completions</li>
+ *   <li>Function calling support</li>
+ *   <li>Image and file attachments</li>
+ *   <li>Observability (metrics, traces, logs)</li>
+ * </ul>
+ *
  * @see ChatModel
  * @see GigaChatApi
+ * @since 1.0.0
  */
 @Slf4j
 public class GigaChatModel implements ChatModel {


### PR DESCRIPTION
## Summary

Added class-level JavaDoc documentation to `GigaChatModel` describing its purpose and key features.

## Changes

- Added JavaDoc comment to `GigaChatModel` class
- Documents that it implements Spring AI ChatModel for GigaChat API
- Mentions support for synchronous and streaming completions

---
*Test PR for Claude Code Review workflow*