### PR TITLE
Improve Claude review prompt format

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -45,13 +45,17 @@ jobs:
             - Security concerns
             - Performance considerations
 
-            IMPORTANT:
-            - Review ONLY the PR diff, not the entire codebase
+            INSTRUCTIONS:
             - Use `gh pr diff` to see the changes
             - Use `gh pr comment` for top-level feedback
-            - Use `mcp__github_inline_comment__create_inline_comment` to highlight specific code issues
+            - Use `mcp__github_inline_comment__create_inline_comment` for specific code issues
             - Provide feedback in Russian if PR description is in Russian, otherwise in English
-            - Only post GitHub comments - don't submit review text as messages
+
+            OUTPUT FORMAT:
+            - If no issues found: just comment "LGTM" (nothing else)
+            - If issues found: list them concisely with inline comments where applicable
+            - Do NOT include internal checklists or verbose explanations
+            - Keep it short and actionable
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Read,Glob,Grep"


### PR DESCRIPTION
Remove internal checklist from review output, make comments more concise and professional.