### PR TITLE
Обновлены Spring AI до 1.1.4, Spring Boot до 3.5.13, commons-lang3 до 3.20.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,12 +59,12 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <allure-bom.version>2.32.0</allure-bom.version>
         <aspectj.version>1.9.25.1</aspectj.version>
-        <spring-boot.version>3.5.10</spring-boot.version>
-        <spring-ai.version>1.1.2</spring-ai.version>
+        <spring-boot.version>3.5.13</spring-boot.version>
+        <spring-ai.version>1.1.4</spring-ai.version>
         <ayza.version>10.0.3</ayza.version>
         <lombok.version>1.18.42</lombok.version>
         <wiremock-spring-boot.version>3.10.6</wiremock-spring-boot.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
 
         <maven.deploy.plugin.version>3.1.4</maven.deploy.plugin.version>
     </properties>

--- a/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/system_prompt_sorting/SystemPromptSortingIT.java
+++ b/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/system_prompt_sorting/SystemPromptSortingIT.java
@@ -23,7 +23,7 @@ public class SystemPromptSortingIT {
     ApplicationContextRunner contextRunner = new ApplicationContextRunner()
             .withConfiguration(AutoConfigurations.of(GigaChatAutoConfiguration.class))
             .withPropertyValues(
-                    "spring.ai.gigachat.scope=" + System.getenv("GIGACHAT_API_SCOPE"),
+                    "spring.ai.gigachat.auth.scope=" + System.getenv("GIGACHAT_API_SCOPE"),
                     "spring.ai.gigachat.auth.bearer.client-id=" + System.getenv("GIGACHAT_API_CLIENT_ID"),
                     "spring.ai.gigachat.auth.bearer.client-secret=" + System.getenv("GIGACHAT_API_CLIENT_SECRET"),
                     "spring.ai.gigachat.auth.unsafe-ssl=true",

--- a/spring-ai-gigachat-example/pom.xml
+++ b/spring-ai-gigachat-example/pom.xml
@@ -11,14 +11,14 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.5.10</version>
+        <version>3.5.13</version>
         <relativePath/>
     </parent>
 
     <properties>
         <java.version>17</java.version>
-        <spring-ai.version>1.1.2</spring-ai.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <spring-ai.version>1.1.4</spring-ai.version>
+        <commons-lang3.version>3.20.0</commons-lang3.version>
     </properties>
 
     <dependencyManagement>

--- a/spring-ai-gigachat-example/src/main/java/chat/giga/springai/example/rag/RagConfiguration.java
+++ b/spring-ai-gigachat-example/src/main/java/chat/giga/springai/example/rag/RagConfiguration.java
@@ -19,7 +19,13 @@ public class RagConfiguration {
             @Value("${rag.min-chunk-length-to-embed:5}") int minChunkLengthToEmbed,
             @Value("${rag.max-num-chunks:10000}") int maxNumChunks,
             @Value("${rag.keep-separator:true}") boolean keepSeparator) {
-        return new TokenTextSplitter(chunkSize, minChunkSizeChars, minChunkLengthToEmbed, maxNumChunks, keepSeparator);
+        return TokenTextSplitter.builder()
+                .withChunkSize(chunkSize)
+                .withMinChunkSizeChars(minChunkSizeChars)
+                .withMinChunkLengthToEmbed(minChunkLengthToEmbed)
+                .withMaxNumChunks(maxNumChunks)
+                .withKeepSeparator(keepSeparator)
+                .build();
     }
 
     @Bean


### PR DESCRIPTION
## Summary

- Spring AI 1.1.2 → 1.1.4 ([release notes](https://github.com/spring-projects/spring-ai/releases/tag/v1.1.4)) — исправления безопасности CVE-2026-22738, CVE-2026-22742, CVE-2026-22743, CVE-2026-22744
- Spring Boot 3.5.10 → 3.5.13 ([release notes](https://github.com/spring-projects/spring-boot/releases/tag/v3.5.13)) — патчи безопасности и багфиксы
- commons-lang3 3.18.0 → 3.20.0
- `TokenTextSplitter`: конструктор заменён на builder (старый deprecated в Spring AI 1.1.4)

## Test plan

- [x] Компиляция всех модулей
- [x] 125 unit-тестов — все зелёные

🤖 Generated with [Claude Code](https://claude.com/claude-code)