### PR TITLE
GH-108 Bump Spring AI to 2.0.0-M4 and Spring Boot to 4.0.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>chat.giga</groupId>
     <artifactId>spring-ai-gigachat-parent</artifactId>
-    <version>2.0.0-M3</version>
+    <version>2.0.0-M4</version>
     <packaging>pom</packaging>
 
     <name>Spring AI model - GigaChat - Parent</name>
@@ -59,8 +59,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <allure-bom.version>2.32.0</allure-bom.version>
         <aspectj.version>1.9.25.1</aspectj.version>
-        <spring-boot.version>4.0.3</spring-boot.version>
-        <spring-ai.version>2.0.0-M3</spring-ai.version>
+        <spring-boot.version>4.0.5</spring-boot.version>
+        <spring-ai.version>2.0.0-M4</spring-ai.version>
         <ayza.version>10.0.3</ayza.version>
         <lombok.version>1.18.42</lombok.version>
         <wiremock-spring-boot.version>4.2.1</wiremock-spring-boot.version>

--- a/spring-ai-autoconfigure-model-gigachat/pom.xml
+++ b/spring-ai-autoconfigure-model-gigachat/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>chat.giga</groupId>
         <artifactId>spring-ai-gigachat-parent</artifactId>
-        <version>2.0.0-M3</version>
+        <version>2.0.0-M4</version>
     </parent>
 
     <artifactId>spring-ai-autoconfigure-model-gigachat</artifactId>

--- a/spring-ai-gigachat-example/pom.xml
+++ b/spring-ai-gigachat-example/pom.xml
@@ -6,18 +6,18 @@
 
     <groupId>chat.giga</groupId>
     <artifactId>spring-ai-gigachat-example</artifactId>
-    <version>2.0.0-M3</version>
+    <version>2.0.0-M4</version>
 
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>4.0.3</version>
+        <version>4.0.5</version>
         <relativePath/>
     </parent>
 
     <properties>
         <java.version>21</java.version>
-        <spring-ai.version>2.0.0-M3</spring-ai.version>
+        <spring-ai.version>2.0.0-M4</spring-ai.version>
         <commons-lang3.version>3.18.0</commons-lang3.version>
     </properties>
 

--- a/spring-ai-gigachat/pom.xml
+++ b/spring-ai-gigachat/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>chat.giga</groupId>
         <artifactId>spring-ai-gigachat-parent</artifactId>
-        <version>2.0.0-M3</version>
+        <version>2.0.0-M4</version>
     </parent>
 
     <artifactId>spring-ai-gigachat</artifactId>

--- a/spring-ai-starter-model-gigachat/pom.xml
+++ b/spring-ai-starter-model-gigachat/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>chat.giga</groupId>
         <artifactId>spring-ai-gigachat-parent</artifactId>
-        <version>2.0.0-M3</version>
+        <version>2.0.0-M4</version>
     </parent>
 
     <artifactId>spring-ai-starter-model-gigachat</artifactId>


### PR DESCRIPTION
Closes #108

## Изменения

- `spring-ai` 2.0.0-M3 → **2.0.0-M4** ([release notes](https://github.com/spring-projects/spring-ai/releases/tag/v2.0.0-M4))
- `spring-boot` 4.0.3 → **4.0.5**
- Версия проекта: 2.0.0-M3 → **2.0.0-M4**

## Затронутые файлы

- `pom.xml`
- `spring-ai-gigachat/pom.xml`
- `spring-ai-autoconfigure-model-gigachat/pom.xml`
- `spring-ai-starter-model-gigachat/pom.xml`
- `spring-ai-gigachat-example/pom.xml`