### PR TITLE
GH-111 Fix Prometheus tag-keys mismatch on image observation

### DIFF
--- a/spring-ai-gigachat/pom.xml
+++ b/spring-ai-gigachat/pom.xml
@@ -60,6 +60,16 @@
             <artifactId>spring-boot-starter-restclient-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-observation-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
@@ -19,8 +19,6 @@ import org.springframework.ai.image.ImageModel;
 import org.springframework.ai.image.ImageOptions;
 import org.springframework.ai.image.ImagePrompt;
 import org.springframework.ai.image.ImageResponse;
-import org.springframework.ai.image.ImageResponseMetadata;
-import org.springframework.ai.image.observation.DefaultImageModelObservationConvention;
 import org.springframework.ai.image.observation.ImageModelObservationContext;
 import org.springframework.ai.image.observation.ImageModelObservationConvention;
 import org.springframework.ai.image.observation.ImageModelObservationDocumentation;
@@ -28,6 +26,25 @@ import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 
+/**
+ * {@link ImageModel} implementation backed by GigaChat. Internally calls the regular
+ * {@code /chat/completions} endpoint with {@code function_call=auto} — the model replies
+ * with an HTML fragment of the form {@code <img src="<file-id>"/>}, from which we extract
+ * the {@code file-id}, download the binary via {@link GigaChatApi#downloadFile(String)}
+ * and assemble an {@link ImageResponse} with a base64-encoded payload.
+ *
+ * <p>The class is instrumented through the Spring AI Observation API: each {@link #call}
+ * produces a {@code gen_ai.client.operation} observation with the {@code image} operation
+ * type. The default convention is {@link GigaChatImageModelObservationConvention} — it
+ * augments the standard tag set with {@code gen_ai.response.model}, restoring tag-key
+ * parity with the chat metric and silencing the {@code PrometheusMeterRegistry} warning
+ * about mismatched tag keys (see issue GH-111). A custom convention can be supplied via
+ * {@link #setObservationConvention(ImageModelObservationConvention)}.
+ *
+ * <p>All network calls to GigaChat are wrapped in {@link GigaRetryTemplate} to provide
+ * resilience against transient failures while preserving the original exception type when
+ * the retry budget is exhausted.
+ */
 @Slf4j
 public class GigaChatImageModel implements ImageModel {
 
@@ -35,7 +52,7 @@ public class GigaChatImageModel implements ImageModel {
     private static final Pattern IMG_ID_PATTERN = Pattern.compile("<img\\s+src=\"([a-fA-F0-9\\-]{36})\"");
 
     private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION =
-            new DefaultImageModelObservationConvention();
+            new GigaChatImageModelObservationConvention();
 
     private final GigaChatApi gigaChatApi;
     private final GigaChatImageOptions defaultOptions;
@@ -44,6 +61,17 @@ public class GigaChatImageModel implements ImageModel {
 
     private ImageModelObservationConvention observationConvention;
 
+    /**
+     * Creates a GigaChat image model with the given API client, default options and
+     * observability/retry infrastructure.
+     *
+     * @param gigaChatApi GigaChat client used for {@code /chat/completions} and file downloads
+     * @param defaultOptions options applied when an {@link ImagePrompt} does not carry its own
+     *     (covers model, style, etc.)
+     * @param observationRegistry registry where observations are published; pass
+     *     {@link ObservationRegistry#NOOP} in tests that do not care about instrumentation
+     * @param retryTemplate retry policy, wrapped into {@link GigaRetryTemplate}
+     */
     public GigaChatImageModel(
             GigaChatApi gigaChatApi,
             GigaChatImageOptions defaultOptions,
@@ -56,6 +84,18 @@ public class GigaChatImageModel implements ImageModel {
         this.retryTemplate = new GigaRetryTemplate(retryTemplate);
     }
 
+    /**
+     * Synchronously generates an image for the given prompt and wraps execution in a Spring AI
+     * observation. If the prompt does not carry options, defaults are applied through
+     * {@link #normalizePrompt(ImagePrompt)}. Once the model responds, the resulting
+     * {@link ImageResponse} is stashed into the observation context — this is required so that
+     * {@code gen_ai.response.model} ends up on the final timer with a real value rather than
+     * the {@code none} placeholder.
+     *
+     * @param prompt image description (text plus generation options)
+     * @return a response containing a single {@link ImageGeneration} (base64 + file_id), or an
+     *     empty result if the model returned nothing usable
+     */
     @Override
     public ImageResponse call(ImagePrompt prompt) {
         ImagePrompt effectivePrompt = normalizePrompt(prompt);
@@ -73,26 +113,49 @@ public class GigaChatImageModel implements ImageModel {
                         DEFAULT_OBSERVATION_CONVENTION,
                         () -> observationContext,
                         this.observationRegistry)
-                .observe(() -> processRequest(effectivePrompt, request));
+                .observe(() -> processRequest(effectivePrompt, request, observationContext));
     }
 
-    private ImageResponse processRequest(ImagePrompt prompt, CompletionRequest request) {
+    /**
+     * Executes the request against GigaChat, parses the response, downloads the binary payload
+     * and assembles an {@link ImageResponse}. On every early exit (empty completion, missing
+     * {@code <img src=...>} tag) the method still publishes a placeholder response into the
+     * observation context, so the {@code gen_ai.response.model} tag is populated correctly even
+     * in negative scenarios.
+     *
+     * @param prompt the prompt after normalization (used for log messages)
+     * @param request a ready-to-send {@link CompletionRequest}
+     * @param observationContext context that receives the final {@link ImageResponse}
+     * @return generation result; an empty {@link ImageResponse} when the model returned no data
+     *     or the file id could not be extracted
+     * @throws IllegalStateException when the file id was extracted but downloading the binary
+     *     produced {@code null}
+     */
+    private ImageResponse processRequest(
+            ImagePrompt prompt, CompletionRequest request, ImageModelObservationContext observationContext) {
         CompletionResponse completion = executeCompletion(request);
 
         if (isEmptyCompletion(completion)) {
             log.warn("GigaChat returned empty image result for prompt: {}", prompt);
-            return new ImageResponse(List.of());
+            ImageResponse empty = new ImageResponse(List.of(), new GigaChatImageResponseMetadata(null));
+            observationContext.setResponse(empty);
+            return empty;
         }
 
         String fileId = extractFileId(completion);
         if (fileId == null) {
             log.warn("Unable to extract file_id from GigaChat response for prompt: {}", prompt);
-            return new ImageResponse(List.of());
+            ImageResponse empty =
+                    new ImageResponse(List.of(), new GigaChatImageResponseMetadata(completion.getModel()));
+            observationContext.setResponse(empty);
+            return empty;
         }
 
         String responseFormat = prompt.getOptions().getResponseFormat();
         if (GigaChatImageOptions.RESPONSE_FORMAT_URL.equals(responseFormat)) {
-            return buildUrlImageResponse(fileId);
+            ImageResponse response = buildUrlImageResponse(fileId, completion.getModel());
+            observationContext.setResponse(response);
+            return response;
         }
 
         byte[] imageBytes = gigaChatApi.downloadFile(fileId);
@@ -100,9 +163,18 @@ public class GigaChatImageModel implements ImageModel {
             throw new IllegalStateException("Failed to download image for fileId: " + fileId);
         }
 
-        return buildBase64ImageResponse(fileId, imageBytes);
+        ImageResponse response = buildBase64ImageResponse(fileId, imageBytes, completion.getModel());
+        observationContext.setResponse(response);
+        return response;
     }
 
+    /**
+     * If the prompt does not carry options, wraps it in a new {@link ImagePrompt} populated with
+     * {@link #defaultOptions}. Otherwise returns the prompt unchanged.
+     *
+     * @param prompt the prompt as passed in by the caller
+     * @return a prompt that is guaranteed to have non-null options
+     */
     private ImagePrompt normalizePrompt(ImagePrompt prompt) {
         if (prompt.getOptions() == null) { // safeguard against changes in Spring AI logic
             return new ImagePrompt(prompt.getInstructions(), defaultOptions);
@@ -122,6 +194,13 @@ public class GigaChatImageModel implements ImageModel {
         return new ImagePrompt(prompt.getInstructions(), mergedOptions);
     }
 
+    /**
+     * Calls GigaChat {@code /chat/completions} through the retry wrapper and unwraps the
+     * response body.
+     *
+     * @param request the request to execute
+     * @return body of the {@link CompletionResponse}, or {@code null} when the HTTP response is empty
+     */
     private CompletionResponse executeCompletion(CompletionRequest request) {
         ResponseEntity<CompletionResponse> entity =
                 retryTemplate.execute(() -> gigaChatApi.chatCompletionEntity(request));
@@ -129,28 +208,70 @@ public class GigaChatImageModel implements ImageModel {
         return Optional.ofNullable(entity).map(ResponseEntity::getBody).orElse(null);
     }
 
+    /**
+     * Checks whether the completion is non-empty and contains at least one {@code choice}.
+     *
+     * @param completion parsed model response (may be {@code null})
+     * @return {@code true} when the completion is missing or carries no choices
+     */
     private boolean isEmptyCompletion(CompletionResponse completion) {
         return completion == null
                 || completion.getChoices() == null
                 || completion.getChoices().isEmpty();
     }
 
-    private ImageResponse buildBase64ImageResponse(String fileId, byte[] imageBytes) {
+    /**
+     * Assembles an {@link ImageResponse} carrying the image as a base64-encoded payload.
+     * Used when the requested {@code response_format} is base64 (the Spring AI default for
+     * GigaChat). The response metadata is set to {@link GigaChatImageResponseMetadata}
+     * populated with the model that the API actually used — this feeds the
+     * {@code gen_ai.response.model} observation tag.
+     *
+     * @param fileId file identifier returned by GigaChat
+     * @param imageBytes downloaded image binary
+     * @param responseModel value of the {@code model} field from {@link CompletionResponse} —
+     *     the model that actually served the request (may differ from the requested one)
+     * @return a response with a single {@link ImageGeneration}
+     */
+    private ImageResponse buildBase64ImageResponse(String fileId, byte[] imageBytes, String responseModel) {
         String base64 = Base64.getEncoder().encodeToString(imageBytes);
         Image image = new Image(null, base64);
         ImageGenerationMetadata metadata = new GigaChatImageGenerationMetadata(fileId);
         ImageGeneration generation = new ImageGeneration(image, metadata);
-        return new ImageResponse(List.of(generation), new ImageResponseMetadata());
+        return new ImageResponse(List.of(generation), new GigaChatImageResponseMetadata(responseModel));
     }
 
-    private ImageResponse buildUrlImageResponse(String fileId) {
+    /**
+     * Assembles an {@link ImageResponse} where {@link Image} carries a downloadable URL
+     * instead of a base64 payload. Used when the caller opted into
+     * {@link GigaChatImageOptions#RESPONSE_FORMAT_URL}, which lets clients stream the image
+     * straight from GigaChat without going through the application memory. The response
+     * metadata mirrors the base64 path so {@code gen_ai.response.model} stays consistent
+     * across both formats.
+     *
+     * @param fileId file identifier returned by GigaChat
+     * @param responseModel value of the {@code model} field from {@link CompletionResponse}
+     * @return a response with a single {@link ImageGeneration} pointing at the file URL
+     */
+    private ImageResponse buildUrlImageResponse(String fileId, String responseModel) {
         String url = gigaChatApi.getFileUrl(fileId);
         Image image = new Image(url, null);
         ImageGenerationMetadata metadata = new GigaChatImageGenerationMetadata(fileId);
         ImageGeneration generation = new ImageGeneration(image, metadata);
-        return new ImageResponse(List.of(generation), new ImageResponseMetadata());
+        return new ImageResponse(List.of(generation), new GigaChatImageResponseMetadata(responseModel));
     }
 
+    /**
+     * Extracts the {@code file-id} from the content of the first choice — the model returns it
+     * wrapped in an HTML fragment {@code <img src="<uuid>"/>}. The method throws when the tag
+     * is absent: this is treated as a contract violation by GigaChat rather than a regular
+     * empty result.
+     *
+     * @param response parsed {@link CompletionResponse} (expected to be non-empty)
+     * @return file UUID
+     * @throws IllegalStateException when the content does not contain the expected
+     *     {@code <img src=...>} tag
+     */
     private String extractFileId(CompletionResponse response) {
         String content = response.getChoices().get(0).getMessage().getContent();
         Matcher matcher = IMG_ID_PATTERN.matcher(content);
@@ -162,6 +283,15 @@ public class GigaChatImageModel implements ImageModel {
         return matcher.group(1);
     }
 
+    /**
+     * Builds the {@link CompletionRequest} for image generation: a system message carrying the
+     * style, a user message with the prompt text, and {@code function_call=auto} (the function
+     * GigaChat uses to trigger image generation). When the prompt carries more than one
+     * instruction, the first one is used and a warning is logged.
+     *
+     * @param prompt prompt with non-null options (already normalized via {@link #normalizePrompt})
+     * @return request ready to be sent to the API
+     */
     private CompletionRequest buildCompletionRequest(ImagePrompt prompt) {
 
         CompletionRequest req = new CompletionRequest();
@@ -202,9 +332,12 @@ public class GigaChatImageModel implements ImageModel {
     }
 
     /**
-     * Use the provided convention for reporting observation data
+     * Overrides the convention used to report observation data. When no convention is set,
+     * {@link GigaChatImageModelObservationConvention} is used by default — it keeps tag keys
+     * symmetric with the chat metric. Pass a custom convention only when the standard tag set
+     * needs to be altered.
      *
-     * @param observationConvention The provided convention
+     * @param observationConvention the convention to install (must not be {@code null})
      */
     public void setObservationConvention(ImageModelObservationConvention observationConvention) {
         Assert.notNull(observationConvention, "observationConvention cannot be null");

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModelObservationConvention.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModelObservationConvention.java
@@ -1,0 +1,67 @@
+package chat.giga.springai.image;
+
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.observation.DefaultImageModelObservationConvention;
+import org.springframework.ai.image.observation.ImageModelObservationContext;
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+import org.springframework.util.StringUtils;
+
+/**
+ * GigaChat-specific convention for image model observations. Extends the Spring AI default
+ * by adding the {@code gen_ai.response.model} low-cardinality tag — Spring AI 2.0.0-M4
+ * omits it for image observations while emitting it for chat observations under the same
+ * meter name {@code gen_ai.client.operation}, which causes Prometheus to reject the second
+ * registration with a tag-keys-mismatch warning. Adding the tag (with {@code "none"} when
+ * the response is unavailable, e.g. on the start side of the long-task timer) restores
+ * tag-set symmetry between the two AI operation types and silences the warning reported
+ * in issue GH-111.
+ */
+public class GigaChatImageModelObservationConvention extends DefaultImageModelObservationConvention {
+
+    private static final String RESPONSE_MODEL = AiObservationAttributes.RESPONSE_MODEL.value();
+
+    private static final KeyValue RESPONSE_MODEL_NONE = KeyValue.of(RESPONSE_MODEL, KeyValue.NONE_VALUE);
+
+    /**
+     * Returns the low-cardinality tags exposed by Spring AI's default image convention plus
+     * the additional {@code gen_ai.response.model} tag computed by {@link #responseModel}.
+     * The order of tags is irrelevant for Prometheus — what matters is that the resulting
+     * <em>set of keys</em> matches the chat convention so that both observations can
+     * coexist under the shared {@code gen_ai.client.operation} meter name.
+     *
+     * @param context observation context populated by {@link GigaChatImageModel}
+     * @return augmented {@link KeyValues}
+     */
+    @Override
+    public KeyValues getLowCardinalityKeyValues(ImageModelObservationContext context) {
+        return super.getLowCardinalityKeyValues(context).and(responseModel(context));
+    }
+
+    /**
+     * Computes the {@code gen_ai.response.model} tag. Reads the model name from
+     * {@link GigaChatImageResponseMetadata} when available; otherwise falls back to
+     * {@link KeyValue#NONE_VALUE}. The fallback covers two cases:
+     * <ul>
+     *     <li>observation start — context.response is still {@code null}, the long-task
+     *         timer captures tags at this moment and the chat convention also reports
+     *         {@code none} here, so emitting {@code none} keeps tag-set parity;</li>
+     *     <li>foreign metadata or an empty model string — defensive defaults to avoid
+     *         publishing a meter with an empty tag value.</li>
+     * </ul>
+     *
+     * @param context observation context whose {@code response} is populated by
+     *     {@link GigaChatImageModel} once the API call succeeds
+     * @return key/value pair for the response model tag
+     */
+    private KeyValue responseModel(ImageModelObservationContext context) {
+        ImageResponse response = context.getResponse();
+        if (response != null
+                && response.getMetadata() instanceof GigaChatImageResponseMetadata metadata
+                && StringUtils.hasText(metadata.getModel())) {
+            return KeyValue.of(RESPONSE_MODEL, metadata.getModel());
+        }
+        return RESPONSE_MODEL_NONE;
+    }
+}

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageResponseMetadata.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageResponseMetadata.java
@@ -1,0 +1,52 @@
+package chat.giga.springai.image;
+
+import org.springframework.ai.image.ImageResponseMetadata;
+
+/**
+ * GigaChat-specific {@link ImageResponseMetadata} that exposes the response model returned
+ * by the API. Without this extra field the
+ * {@link GigaChatImageModelObservationConvention} would not be able to populate the
+ * {@code gen_ai.response.model} low-cardinality tag, which keeps the image metric tag set
+ * in parity with the chat metric and avoids the Prometheus "tag keys mismatch" warning
+ * (issue GH-111).
+ */
+public class GigaChatImageResponseMetadata extends ImageResponseMetadata {
+
+    private final String model;
+
+    /**
+     * Creates metadata with the given model name and a creation timestamp set to "now"
+     * (delegated to {@link ImageResponseMetadata#ImageResponseMetadata()}).
+     *
+     * @param model the model that actually produced the image, as reported by the API in
+     *     {@code CompletionResponse.model}; may be {@code null} when GigaChat returned an
+     *     empty completion and we have nothing to record
+     */
+    public GigaChatImageResponseMetadata(String model) {
+        super();
+        this.model = model;
+    }
+
+    /**
+     * Creates metadata with explicit creation timestamp and model name.
+     *
+     * @param created creation timestamp in epoch millis, see
+     *     {@link ImageResponseMetadata#ImageResponseMetadata(Long)}
+     * @param model the model that actually produced the image (see {@link #GigaChatImageResponseMetadata(String)})
+     */
+    public GigaChatImageResponseMetadata(Long created, String model) {
+        super(created);
+        this.model = model;
+    }
+
+    /**
+     * Returns the response model — the value of {@code model} from the underlying
+     * GigaChat {@code /chat/completions} response. May differ from the requested model
+     * (e.g. when GigaChat routes to a specific sub-version).
+     *
+     * @return response model id, or {@code null} if it was unavailable
+     */
+    public String getModel() {
+        return model;
+    }
+}

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatChatImageMetricsCoexistenceIT.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatChatImageMetricsCoexistenceIT.java
@@ -1,0 +1,224 @@
+package chat.giga.springai.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import chat.giga.springai.api.chat.GigaChatApi;
+import chat.giga.springai.api.chat.completion.CompletionResponse;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.observation.DefaultMeterObservationHandler;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.prometheusmetrics.PrometheusConfig;
+import io.micrometer.prometheusmetrics.PrometheusMeterRegistry;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.chat.messages.UserMessage;
+import org.springframework.ai.chat.metadata.ChatResponseMetadata;
+import org.springframework.ai.chat.model.ChatResponse;
+import org.springframework.ai.chat.observation.ChatModelObservationContext;
+import org.springframework.ai.chat.observation.ChatModelObservationDocumentation;
+import org.springframework.ai.chat.observation.DefaultChatModelObservationConvention;
+import org.springframework.ai.chat.prompt.ChatOptions;
+import org.springframework.ai.chat.prompt.Prompt;
+import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Reproduces the scenario from issue GH-111: chat and image observations publish to the
+ * shared {@code gen_ai.client.operation} meter in a single {@link PrometheusMeterRegistry}.
+ * If the two observations expose different low-cardinality tag key sets, Prometheus
+ * rejects the second registration and logs a WARN. This test exercises both orderings
+ * (chat→image and image→chat) and asserts that both time series end up in the registry
+ * with identical tag key sets, which is the structural contract that keeps the warning
+ * away.
+ */
+class GigaChatChatImageMetricsCoexistenceIT {
+
+    private static final String CHAT_REQUEST_MODEL = "GigaChat-2";
+    private static final String CHAT_RESPONSE_MODEL = "GigaChat-2-Pro";
+    private static final String IMAGE_REQUEST_MODEL = "GigaChat-2";
+    private static final String IMAGE_RESPONSE_MODEL = "GigaChat-2-Pro";
+
+    private final GigaChatApi gigaChatApi = Mockito.mock(GigaChatApi.class);
+    private final RetryTemplate retryTemplate = org.springframework.ai.retry.RetryUtils.DEFAULT_RETRY_TEMPLATE;
+
+    /**
+     * Stubs both {@link GigaChatApi#chatCompletionEntity} and
+     * {@link GigaChatApi#downloadFile} so {@link GigaChatImageModel} can run end-to-end
+     * without a real HTTP backend. The stub deliberately reports a different model in the
+     * response than what was requested, mirroring how GigaChat routes traffic to a specific
+     * sub-version.
+     */
+    private void stubImageApi() {
+        CompletionResponse.MessagesRes message = new CompletionResponse.MessagesRes();
+        message.setRole(CompletionResponse.Role.assistant);
+        message.setContent("<img src=\"44444444-5555-6666-7777-888888888888\"/>");
+
+        CompletionResponse.Choice choice = new CompletionResponse.Choice();
+        choice.setMessage(message);
+        choice.setFinishReason(CompletionResponse.FinishReason.STOP);
+        choice.setIndex(0);
+
+        CompletionResponse completion = new CompletionResponse();
+        completion.setChoices(List.of(choice));
+        completion.setModel(IMAGE_RESPONSE_MODEL);
+
+        Mockito.when(gigaChatApi.chatCompletionEntity(any())).thenReturn(ResponseEntity.ok(completion));
+        Mockito.when(gigaChatApi.downloadFile("44444444-5555-6666-7777-888888888888"))
+                .thenReturn(new byte[] {1, 2, 3});
+    }
+
+    /**
+     * Builds an {@link ObservationRegistry} wired to push every observation into the given
+     * {@link PrometheusMeterRegistry} via {@link DefaultMeterObservationHandler}. This is the
+     * same pipeline Spring Boot sets up for users — issue GH-111 was reported against this
+     * exact configuration.
+     *
+     * @param meterRegistry meter registry that will receive the observations
+     * @return observation registry plumbed to the meter registry
+     */
+    private ObservationRegistry observationRegistry(PrometheusMeterRegistry meterRegistry) {
+        ObservationRegistry registry = ObservationRegistry.create();
+        registry.observationConfig().observationHandler(new DefaultMeterObservationHandler(meterRegistry));
+        return registry;
+    }
+
+    /**
+     * Simulates a chat call the same way {@code GigaChatModel} does — directly through
+     * {@link ChatModelObservationDocumentation}, without instantiating the full model. We
+     * only care about how the chat observation registers with the meter registry, so this
+     * keeps the test self-contained and avoids mocking the heavier chat dependencies.
+     *
+     * @param observationRegistry the shared registry under test
+     */
+    private void runChatObservation(ObservationRegistry observationRegistry) {
+        Prompt prompt = new Prompt(
+                List.of(new UserMessage("hi")),
+                ChatOptions.builder().model(CHAT_REQUEST_MODEL).build());
+        ChatModelObservationContext ctx = ChatModelObservationContext.builder()
+                .prompt(prompt)
+                .provider(GigaChatApi.PROVIDER_NAME)
+                .build();
+
+        ChatModelObservationDocumentation.CHAT_MODEL_OPERATION
+                .observation(null, new DefaultChatModelObservationConvention(), () -> ctx, observationRegistry)
+                .observe(() -> {
+                    ctx.setResponse(new ChatResponse(
+                            List.of(),
+                            ChatResponseMetadata.builder()
+                                    .model(CHAT_RESPONSE_MODEL)
+                                    .build()));
+                    return null;
+                });
+    }
+
+    /**
+     * Drives a real {@link GigaChatImageModel} call against the shared registry. The image
+     * side goes through the production path (including
+     * {@link GigaChatImageModelObservationConvention}) — that is exactly the code we want
+     * to verify behaves symmetrically with chat.
+     *
+     * @param observationRegistry the shared registry under test
+     */
+    private void runImageCall(ObservationRegistry observationRegistry) {
+        GigaChatImageModel imageModel = new GigaChatImageModel(
+                gigaChatApi,
+                GigaChatImageOptions.builder().model(IMAGE_REQUEST_MODEL).build(),
+                observationRegistry,
+                retryTemplate);
+        imageModel.call(new ImagePrompt(
+                List.of(new ImageMessage("Нарисуй кота", 1.0f)),
+                GigaChatImageOptions.builder().model(IMAGE_REQUEST_MODEL).build()));
+    }
+
+    /**
+     * Asserts the structural invariant that protects against the bug from GH-111:
+     * <ul>
+     *     <li>two meters registered under {@code gen_ai.client.operation} (one per
+     *         operation type — chat and image); if Prometheus rejected the second
+     *         registration due to a tag-keys mismatch we would see only one;</li>
+     *     <li>both meters expose identical sets of tag keys;</li>
+     *     <li>the four required GenAI low-cardinality keys are present;</li>
+     *     <li>the {@code gen_ai.operation.name} values are exactly {chat, image}.</li>
+     * </ul>
+     *
+     * @param meterRegistry registry to inspect
+     */
+    private void assertCoexistence(PrometheusMeterRegistry meterRegistry) {
+        Collection<Meter> meters = meterRegistry.find("gen_ai.client.operation").meters();
+
+        assertThat(meters)
+                .as("Both series (chat + image) must be registered. "
+                        + "If Prometheus rejected the second registration because of mismatched tag keys, "
+                        + "this collection will only have one entry.")
+                .hasSize(2);
+
+        List<Set<String>> tagKeySets = meters.stream()
+                .map(m -> m.getId().getTags().stream().map(Tag::getKey).collect(Collectors.toSet()))
+                .toList();
+
+        assertThat(tagKeySets.get(0))
+                .as("Tag key sets for chat and image must be equal — otherwise Prometheus fails the registration")
+                .isEqualTo(tagKeySets.get(1));
+
+        assertThat(tagKeySets.get(0))
+                .contains(
+                        AiObservationAttributes.AI_OPERATION_TYPE.value(),
+                        AiObservationAttributes.AI_PROVIDER.value(),
+                        AiObservationAttributes.REQUEST_MODEL.value(),
+                        AiObservationAttributes.RESPONSE_MODEL.value());
+
+        Set<String> operationTypes = meters.stream()
+                .map(m -> m.getId().getTag(AiObservationAttributes.AI_OPERATION_TYPE.value()))
+                .collect(Collectors.toSet());
+        assertThat(operationTypes)
+                .as("One meter must be chat, the other image")
+                .containsExactlyInAnyOrder("chat", "image");
+    }
+
+    /**
+     * Chat observation registers first, image observation second. This is the exact order
+     * reported in the issue (a user-facing app starts with chat, then triggers image).
+     */
+    @Test
+    @DisplayName("chat → image: both observations register in one PrometheusMeterRegistry without tag conflict")
+    void chatThenImageBothRegister() {
+        PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        ObservationRegistry observationRegistry = observationRegistry(meterRegistry);
+
+        stubImageApi();
+
+        runChatObservation(observationRegistry);
+        runImageCall(observationRegistry);
+
+        assertCoexistence(meterRegistry);
+    }
+
+    /**
+     * Reverse ordering: image observation registers first, then chat. Even though the
+     * meter name is the same, switching the registration order should not change the
+     * outcome — both must succeed.
+     */
+    @Test
+    @DisplayName("image → chat: reverse order does not trigger a registration conflict either")
+    void imageThenChatBothRegister() {
+        PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+        ObservationRegistry observationRegistry = observationRegistry(meterRegistry);
+
+        stubImageApi();
+
+        runImageCall(observationRegistry);
+        runChatObservation(observationRegistry);
+
+        assertCoexistence(meterRegistry);
+    }
+}

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageModelObservationConventionTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageModelObservationConventionTest.java
@@ -1,0 +1,154 @@
+package chat.giga.springai.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import chat.giga.springai.api.chat.GigaChatApi;
+import io.micrometer.common.KeyValue;
+import io.micrometer.common.KeyValues;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.image.Image;
+import org.springframework.ai.image.ImageGeneration;
+import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.image.ImageResponse;
+import org.springframework.ai.image.observation.DefaultImageModelObservationConvention;
+import org.springframework.ai.image.observation.ImageModelObservationContext;
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+
+/**
+ * Unit tests for {@link GigaChatImageModelObservationConvention}. Each test exercises the
+ * convention in isolation by feeding it a hand-built {@link ImageModelObservationContext}
+ * and inspecting the produced low-cardinality {@link KeyValues}, so that the rules used
+ * to populate {@code gen_ai.response.model} stay explicit and regress-free.
+ */
+class GigaChatImageModelObservationConventionTest {
+
+    private static final String GIGA_CHAT_2 = "GigaChat-2";
+    private static final String GIGA_CHAT_2_PRO = "GigaChat-2-Pro";
+
+    private final GigaChatImageModelObservationConvention convention = new GigaChatImageModelObservationConvention();
+
+    /**
+     * Builds a minimal {@link ImageModelObservationContext} representing a request to model
+     * {@link #GIGA_CHAT_2}. Tests that need a populated response call {@code setResponse}
+     * on the returned context.
+     *
+     * @return fresh context shared across the test methods
+     */
+    private ImageModelObservationContext context() {
+        ImagePrompt prompt = new ImagePrompt(
+                List.of(new ImageMessage("Нарисуй кота", 1.0f)),
+                GigaChatImageOptions.builder().model(GIGA_CHAT_2).build());
+        return ImageModelObservationContext.builder()
+                .imagePrompt(prompt)
+                .provider(GigaChatApi.PROVIDER_NAME)
+                .build();
+    }
+
+    /**
+     * At observation start the response is not yet available — the long-task timer
+     * captures tags exactly at this moment, so emitting {@code none} keeps tag-set parity
+     * with the chat convention which also reports {@code none} on the start side.
+     */
+    @Test
+    @DisplayName("At observation start (response not set yet) the gen_ai.response.model tag is none")
+    void responseModelTagIsNoneBeforeResponseIsSet() {
+        KeyValues keyValues = convention.getLowCardinalityKeyValues(context());
+
+        assertThat(keyValues)
+                .contains(KeyValue.of(AiObservationAttributes.RESPONSE_MODEL.value(), KeyValue.NONE_VALUE));
+    }
+
+    /**
+     * Once {@link GigaChatImageResponseMetadata} is attached to the response, the tag must
+     * carry the model that the API actually used — which is the value finally written to
+     * the {@code gen_ai.client.operation} timer.
+     */
+    @Test
+    @DisplayName("After setResponse with a real model — the tag carries the API value")
+    void responseModelTagReflectsActualResponseModel() {
+        ImageModelObservationContext ctx = context();
+        ImageResponse response = new ImageResponse(
+                List.of(new ImageGeneration(new Image(null, "AAAA"))),
+                new GigaChatImageResponseMetadata(GIGA_CHAT_2_PRO));
+        ctx.setResponse(response);
+
+        KeyValues keyValues = convention.getLowCardinalityKeyValues(ctx);
+
+        assertThat(keyValues).contains(KeyValue.of(AiObservationAttributes.RESPONSE_MODEL.value(), GIGA_CHAT_2_PRO));
+    }
+
+    /**
+     * Defensive default: if a third party sets a plain {@code ImageResponseMetadata} on
+     * the response (i.e. not our subclass), the convention must not crash and must fall
+     * back to {@code none}.
+     */
+    @Test
+    @DisplayName("If response.metadata is not GigaChatImageResponseMetadata — the tag falls back to none")
+    void responseModelTagIsNoneForUnknownMetadataType() {
+        ImageModelObservationContext ctx = context();
+        ImageResponse response = new ImageResponse(List.of(new ImageGeneration(new Image(null, "AAAA"))));
+        ctx.setResponse(response);
+
+        KeyValues keyValues = convention.getLowCardinalityKeyValues(ctx);
+
+        assertThat(keyValues)
+                .contains(KeyValue.of(AiObservationAttributes.RESPONSE_MODEL.value(), KeyValue.NONE_VALUE));
+    }
+
+    /**
+     * An empty string from the API ({@code ""}) is treated like a missing value to avoid
+     * publishing a meter with an empty label, which is generally undesirable for Prometheus
+     * scrape outputs.
+     */
+    @Test
+    @DisplayName("Empty model in metadata → the tag falls back to none, avoiding meters with empty labels")
+    void responseModelTagIsNoneForEmptyModel() {
+        ImageModelObservationContext ctx = context();
+        ImageResponse response = new ImageResponse(
+                List.of(new ImageGeneration(new Image(null, "AAAA"))), new GigaChatImageResponseMetadata(""));
+        ctx.setResponse(response);
+
+        KeyValues keyValues = convention.getLowCardinalityKeyValues(ctx);
+
+        assertThat(keyValues)
+                .contains(KeyValue.of(AiObservationAttributes.RESPONSE_MODEL.value(), KeyValue.NONE_VALUE));
+    }
+
+    /**
+     * Pins the structural contract: the image convention exposes exactly the same four
+     * low-cardinality keys that {@code DefaultChatModelObservationConvention} does. This is
+     * the property that protects against the GH-111 Prometheus warning.
+     */
+    @Test
+    @DisplayName(
+            "Image low-cardinality tag set is symmetric with chat (operation, provider, request.model, response.model)")
+    void lowCardinalityTagSetMatchesChatMetric() {
+        KeyValues keyValues = convention.getLowCardinalityKeyValues(context());
+
+        List<String> tagKeys = keyValues.stream().map(KeyValue::getKey).sorted().toList();
+
+        assertThat(tagKeys)
+                .containsExactlyInAnyOrder(
+                        AiObservationAttributes.AI_OPERATION_TYPE.value(),
+                        AiObservationAttributes.AI_PROVIDER.value(),
+                        AiObservationAttributes.REQUEST_MODEL.value(),
+                        AiObservationAttributes.RESPONSE_MODEL.value());
+    }
+
+    /**
+     * Sanity check that we extend the default convention rather than replace it: every
+     * tag the upstream {@link DefaultImageModelObservationConvention} produces must remain
+     * present in our augmented output.
+     */
+    @Test
+    @DisplayName("All tags emitted by DefaultImageModelObservationConvention are preserved alongside response.model")
+    void allDefaultTagsArePreserved() {
+        KeyValues defaultTags = new DefaultImageModelObservationConvention().getLowCardinalityKeyValues(context());
+        KeyValues customTags = convention.getLowCardinalityKeyValues(context());
+
+        assertThat(customTags).containsAll(defaultTags);
+    }
+}

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageModelTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageModelTest.java
@@ -12,6 +12,7 @@ import chat.giga.springai.api.chat.completion.CompletionResponse;
 import io.micrometer.observation.ObservationRegistry;
 import java.util.Base64;
 import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
@@ -22,6 +23,11 @@ import org.springframework.ai.image.ImageResponse;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.ResponseEntity;
 
+/**
+ * Unit tests for {@link GigaChatImageModel}, covering the happy-path generation flow and the
+ * propagation of the API-reported model into {@link GigaChatImageResponseMetadata} (which in
+ * turn feeds the {@code gen_ai.response.model} observation tag).
+ */
 class GigaChatImageModelTest {
 
     private static final String GIGA_CHAT_2_MAX = "GigaChat-2-Max";
@@ -36,6 +42,13 @@ class GigaChatImageModelTest {
     GigaChatImageModel imageModel =
             new GigaChatImageModel(gigaChatApi, defaultOptions, ObservationRegistry.NOOP, retryTemplate);
 
+    /**
+     * End-to-end sanity check: a stubbed {@code /chat/completions} returns a single choice
+     * with an {@code <img src="..."/>} tag, the file is "downloaded", and the resulting
+     * {@link ImageResponse} contains a base64-encoded payload, the original {@code fileId}
+     * inside {@link GigaChatImageGenerationMetadata} and the API-reported model inside
+     * {@link GigaChatImageResponseMetadata}.
+     */
     @Test
     void testSuccessfulImageGenerationB64Json() {
         CompletionResponse completionResponse = createCompletionResponse();
@@ -67,6 +80,9 @@ class GigaChatImageModelTest {
         assertEquals(
                 "11111111-2222-3333-4444-555555555555",
                 ((GigaChatImageGenerationMetadata) gen.getMetadata()).getFileId());
+
+        assertInstanceOf(GigaChatImageResponseMetadata.class, response.getMetadata());
+        assertEquals(GIGA_CHAT_2_MAX, ((GigaChatImageResponseMetadata) response.getMetadata()).getModel());
 
         Mockito.verify(gigaChatApi, Mockito.times(1)).chatCompletionEntity(any());
         Mockito.verify(gigaChatApi, Mockito.times(1)).downloadFile("11111111-2222-3333-4444-555555555555");
@@ -201,6 +217,45 @@ class GigaChatImageModelTest {
         assertEquals("Custom style", systemMessage.getContent());
 
         Mockito.verify(gigaChatApi, Mockito.times(1)).downloadFile("11111111-2222-3333-4444-555555555555");
+    }
+
+    /**
+     * Verifies that the response metadata carries the model reported by the API rather than
+     * the one requested. GigaChat may route the request to a sub-version (e.g. request
+     * {@code GigaChat-2}, get back {@code GigaChat-2-Pro}); the observation tag must reflect
+     * the model that actually served the call.
+     */
+    @Test
+    @DisplayName("Response metadata carries the actual API model even when it differs from the requested one")
+    void responseMetadataReflectsActualModelFromApi() {
+        String actualModel = "GigaChat-2-Pro";
+
+        CompletionResponse.MessagesRes message = new CompletionResponse.MessagesRes();
+        message.setRole(CompletionResponse.Role.assistant);
+        message.setContent("Generated <img src=\"22222222-3333-4444-5555-666666666666\"/>");
+
+        CompletionResponse.Choice choice = new CompletionResponse.Choice();
+        choice.setMessage(message);
+        choice.setFinishReason(CompletionResponse.FinishReason.STOP);
+        choice.setIndex(0);
+
+        CompletionResponse completionResponse = new CompletionResponse();
+        completionResponse.setChoices(List.of(choice));
+        completionResponse.setModel(actualModel);
+        completionResponse.setUsage(null);
+
+        Mockito.when(gigaChatApi.chatCompletionEntity(any())).thenReturn(ResponseEntity.ok(completionResponse));
+        Mockito.when(gigaChatApi.downloadFile("22222222-3333-4444-5555-666666666666"))
+                .thenReturn(new byte[] {9, 9, 9});
+
+        ImagePrompt prompt = new ImagePrompt(
+                List.of(new ImageMessage("Draw something", 1.0f)),
+                ImageOptionsBuilder.builder().build());
+
+        ImageResponse response = imageModel.call(prompt);
+
+        assertInstanceOf(GigaChatImageResponseMetadata.class, response.getMetadata());
+        assertEquals(actualModel, ((GigaChatImageResponseMetadata) response.getMetadata()).getModel());
     }
 
     private CompletionResponse createCompletionResponse() {

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageObservationIT.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageObservationIT.java
@@ -1,0 +1,146 @@
+package chat.giga.springai.image;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+import chat.giga.springai.api.chat.GigaChatApi;
+import chat.giga.springai.api.chat.completion.CompletionResponse;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.micrometer.observation.ObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistry;
+import io.micrometer.observation.tck.TestObservationRegistryAssert;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.ai.image.ImageMessage;
+import org.springframework.ai.image.ImagePrompt;
+import org.springframework.ai.observation.conventions.AiObservationAttributes;
+import org.springframework.core.retry.RetryTemplate;
+import org.springframework.http.ResponseEntity;
+
+/**
+ * Integration test for the observability behavior of {@link GigaChatImageModel}. Reproduces
+ * the scenario from issue GH-111: when chat and image observations share the same meter name
+ * {@code gen_ai.client.operation}, their low-cardinality tag keys must match — otherwise
+ * Prometheus rejects the second registration. This test asserts that the image flow emits
+ * the {@code gen_ai.response.model} tag both at observation start (with NONE_VALUE) and at
+ * stop (with the real model returned by the API), keeping tag-set parity with chat.
+ */
+class GigaChatImageObservationIT {
+
+    private static final String MODEL_REQUESTED = "GigaChat-2";
+    private static final String MODEL_RESPONDED = "GigaChat-2-Pro";
+
+    private final GigaChatApi gigaChatApi = Mockito.mock(GigaChatApi.class);
+    private final GigaChatImageOptions defaultOptions =
+            GigaChatImageOptions.builder().model(MODEL_REQUESTED).build();
+    private final RetryTemplate retryTemplate = org.springframework.ai.retry.RetryUtils.DEFAULT_RETRY_TEMPLATE;
+
+    /**
+     * Stubs both API calls used by {@link GigaChatImageModel#call} so the test does not
+     * touch the network. The stubbed completion intentionally returns a different model
+     * name than the one requested, mirroring how GigaChat may route to a sub-version and
+     * giving us a real value to assert against on the {@code gen_ai.response.model} tag.
+     */
+    private void stubSuccessfulImageGeneration() {
+        CompletionResponse.MessagesRes message = new CompletionResponse.MessagesRes();
+        message.setRole(CompletionResponse.Role.assistant);
+        message.setContent("Generated <img src=\"33333333-4444-5555-6666-777777777777\"/>");
+
+        CompletionResponse.Choice choice = new CompletionResponse.Choice();
+        choice.setMessage(message);
+        choice.setFinishReason(CompletionResponse.FinishReason.STOP);
+        choice.setIndex(0);
+
+        CompletionResponse completionResponse = new CompletionResponse();
+        completionResponse.setChoices(List.of(choice));
+        completionResponse.setModel(MODEL_RESPONDED);
+
+        Mockito.when(gigaChatApi.chatCompletionEntity(any())).thenReturn(ResponseEntity.ok(completionResponse));
+        Mockito.when(gigaChatApi.downloadFile("33333333-4444-5555-6666-777777777777"))
+                .thenReturn(new byte[] {1, 2, 3});
+    }
+
+    /**
+     * Drives an image call through the full Spring AI observation pipeline backed by a
+     * {@link SimpleMeterRegistry}, then inspects the resulting {@code gen_ai.client.operation}
+     * timer. Confirms that all four required low-cardinality keys are present and that
+     * {@code gen_ai.response.model} carries the model from {@code CompletionResponse}, not
+     * the requested one.
+     */
+    @Test
+    @DisplayName("Final timer gen_ai.client.operation carries gen_ai.response.model with the API-reported model")
+    void finalTimerContainsResponseModelTagFromApi() {
+        SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+        ObservationRegistry observationRegistry = ObservationRegistry.create();
+        observationRegistry
+                .observationConfig()
+                .observationHandler(
+                        new io.micrometer.core.instrument.observation.DefaultMeterObservationHandler(meterRegistry));
+
+        GigaChatImageModel imageModel =
+                new GigaChatImageModel(gigaChatApi, defaultOptions, observationRegistry, retryTemplate);
+
+        stubSuccessfulImageGeneration();
+
+        imageModel.call(new ImagePrompt(
+                List.of(new ImageMessage("Нарисуй кота", 1.0f)),
+                GigaChatImageOptions.builder().model(MODEL_REQUESTED).build()));
+
+        Meter timer = meterRegistry.find("gen_ai.client.operation").meter();
+        assertThat(timer)
+                .as("gen_ai.client.operation meter must be registered for the image operation")
+                .isNotNull();
+
+        Set<String> tagKeys = timer.getId().getTags().stream().map(Tag::getKey).collect(Collectors.toSet());
+        assertThat(tagKeys)
+                .as(
+                        "Image timer must expose the same low-cardinality tag keys as chat — otherwise Prometheus fails the registration")
+                .contains(
+                        AiObservationAttributes.AI_OPERATION_TYPE.value(),
+                        AiObservationAttributes.AI_PROVIDER.value(),
+                        AiObservationAttributes.REQUEST_MODEL.value(),
+                        AiObservationAttributes.RESPONSE_MODEL.value());
+
+        assertThat(timer.getId().getTag(AiObservationAttributes.RESPONSE_MODEL.value()))
+                .as("gen_ai.response.model tag must reflect CompletionResponse.model, not the requested model")
+                .isEqualTo(MODEL_RESPONDED);
+    }
+
+    /**
+     * Same flow asserted via {@link TestObservationRegistry} TCK helpers — instead of
+     * inspecting meters, this test verifies the observation lifecycle (started → stopped)
+     * and the four low-cardinality key-value pairs the convention is supposed to publish.
+     * The two tests complement each other: the meter-level test guards the Prometheus
+     * symptom, the observation-level test guards the contract on the Observation API side.
+     */
+    @Test
+    @DisplayName("TestObservationRegistry: image observation completes with the gen_ai.response.model tag")
+    void observationCompletesWithResponseModelTag() {
+        TestObservationRegistry observationRegistry = TestObservationRegistry.create();
+
+        GigaChatImageModel imageModel =
+                new GigaChatImageModel(gigaChatApi, defaultOptions, observationRegistry, retryTemplate);
+
+        stubSuccessfulImageGeneration();
+
+        imageModel.call(new ImagePrompt(
+                List.of(new ImageMessage("Нарисуй кота", 1.0f)),
+                GigaChatImageOptions.builder().model(MODEL_REQUESTED).build()));
+
+        TestObservationRegistryAssert.assertThat(observationRegistry)
+                .hasObservationWithNameEqualTo("gen_ai.client.operation")
+                .that()
+                .hasBeenStarted()
+                .hasBeenStopped()
+                .hasLowCardinalityKeyValue(AiObservationAttributes.AI_OPERATION_TYPE.value(), "image")
+                .hasLowCardinalityKeyValue(AiObservationAttributes.AI_PROVIDER.value(), GigaChatApi.PROVIDER_NAME)
+                .hasLowCardinalityKeyValue(AiObservationAttributes.REQUEST_MODEL.value(), MODEL_REQUESTED)
+                .hasLowCardinalityKeyValue(AiObservationAttributes.RESPONSE_MODEL.value(), MODEL_RESPONDED);
+    }
+}


### PR DESCRIPTION
Closes #111

## Summary

Spring AI 2.0.0-M4 publishes chat and image observations under the same meter name `gen_ai.client.operation`, but with different low-cardinality tag key sets:

| convention | tag keys |
|---|---|
| `DefaultChatModelObservationConvention` | `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, **`gen_ai.response.model`** |
| `DefaultImageModelObservationConvention` | `gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model` |

Prometheus rejects the second registration whenever both flows are exercised in the same process and logs:

```
The meter (MeterId{name='gen_ai.client.operation.active', ...}) registration has failed:
Prometheus requires that all meters with the same name have the same set of tag keys.
```

This PR introduces a GigaChat-specific image convention that augments the default with the missing `gen_ai.response.model` tag, restoring tag-set symmetry with chat.

## Implementation

* `GigaChatImageModelObservationConvention` extends `DefaultImageModelObservationConvention` and adds `gen_ai.response.model` to the low-cardinality key values. The value is read from `CompletionResponse.model` (the real model that served the request — may differ from the requested one) and falls back to `KeyValue.NONE_VALUE` when the response is unavailable, matching what chat reports on the start side of the long-task timer.
* `GigaChatImageResponseMetadata` extends `ImageResponseMetadata` with a typed `model` field, so the convention can read the value without resorting to map keys.
* `GigaChatImageModel` wires the new convention as default and publishes the response into the observation context inside the `observe(...)` lambda so the final timer sees the API-reported model.

## Tests

| class | type | what it covers |
|---|---|---|
| `GigaChatImageModelObservationConventionTest` | unit | each branch of `responseModel`: none on start, real value after `setResponse`, fallback for foreign metadata or empty model, structural parity with chat tag set, preservation of all default tags |
| `GigaChatImageModelTest` | unit | metadata propagation when API reports a model that differs from the requested one |
| `GigaChatImageObservationIT` | IT | full observation pipeline via `SimpleMeterRegistry` and `TestObservationRegistry`; final timer carries the API model |
| `GigaChatChatImageMetricsCoexistenceIT` | IT | both `chat→image` and `image→chat` orderings against a shared `PrometheusMeterRegistry`; both series register and expose identical tag key sets — the exact scenario from the issue |

Verified that `GigaChatChatImageMetricsCoexistenceIT` actually catches the regression by temporarily reverting the convention to the default — the test fails with chat producing 5 keys and image producing 4 (missing `gen_ai.response.model`), which is precisely the diff described in the warning.

Added `micrometer-observation-test` and `micrometer-registry-prometheus` as test-scope dependencies.

## Test plan

- [x] Unit tests: `mvn -pl spring-ai-gigachat test` — 132/132 green
- [x] Integration tests: `mvn -pl spring-ai-gigachat -Pintegration-tests verify` — 4/4 green (including coexistence and TestObservationRegistry)
- [x] Existing IT with real GigaChat API: `GigaChatAutoConfigurationIT.imageInteractionTest`, `GigaChatApiIT`, `MultimodalityIT`, `SystemPromptSortingIT` — all green; the fix does not regress production flow
- [x] Negative verification — temporarily restored `DefaultImageModelObservationConvention` and confirmed `GigaChatChatImageMetricsCoexistenceIT` reproduces the GH-111 tag-set mismatch

🤖 Generated with [Claude Code](https://claude.com/claude-code)