### PR TITLE
fix: copy caching advisor headers

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/advisor/GigaChatCachingAdvisor.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/advisor/GigaChatCachingAdvisor.java
@@ -1,6 +1,8 @@
 package chat.giga.springai.advisor;
 
 import chat.giga.springai.GigaChatOptions;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Optional;
 import org.springframework.ai.chat.client.ChatClientRequest;
 import org.springframework.ai.chat.client.ChatClientResponse;
@@ -49,7 +51,10 @@ public class GigaChatCachingAdvisor implements CallAdvisor, StreamAdvisor {
                 .ifPresent(it -> {
                     String sessionId = (String) chatClientRequest.context().get(X_SESSION_ID);
                     if (sessionId != null) {
-                        it.getHttpHeaders().put(X_SESSION_ID, sessionId);
+                        Map<String, String> existing = it.getHttpHeaders();
+                        Map<String, String> headers = existing == null ? new HashMap<>() : new HashMap<>(existing);
+                        headers.put(X_SESSION_ID, sessionId);
+                        it.setHttpHeaders(headers);
                     }
                 });
     }

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/advisor/GigaChatCachingAdvisorTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/advisor/GigaChatCachingAdvisorTest.java
@@ -1,5 +1,6 @@
 package chat.giga.springai.advisor;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -7,6 +8,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import chat.giga.springai.GigaChatOptions;
+import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -127,6 +129,33 @@ class GigaChatCachingAdvisorTest {
 
         assertNull(requestCaptor.getValue().context().get(GigaChatCachingAdvisor.X_SESSION_ID));
         assertNull(getSessionId(requestCaptor.getValue().prompt().getOptions()));
+    }
+
+    @Test
+    @DisplayName("Адвизор не мутирует переданную immutable map httpHeaders")
+    void testAdviseCall_withImmutableHttpHeaders() {
+        Map<String, String> immutableHeaders = Map.of("X-Existing-Header", "existing-value");
+        GigaChatOptions options =
+                GigaChatOptions.builder().httpHeaders(immutableHeaders).build();
+        ChatClientRequest request = ChatClientRequest.builder()
+                .prompt(Prompt.builder()
+                        .messages(mockMessage)
+                        .chatOptions(options)
+                        .build())
+                .context(GigaChatCachingAdvisor.X_SESSION_ID, X_SESSION_ID_VALUE)
+                .build();
+
+        assertDoesNotThrow(() -> advisor.adviseCall(request, chain));
+
+        ArgumentCaptor<ChatClientRequest> requestCaptor = ArgumentCaptor.forClass(ChatClientRequest.class);
+        verify(chain).nextCall(requestCaptor.capture());
+
+        GigaChatOptions resultOptions =
+                (GigaChatOptions) requestCaptor.getValue().prompt().getOptions();
+        assertEquals(X_SESSION_ID_VALUE, resultOptions.getHttpHeaders().get(GigaChatCachingAdvisor.X_SESSION_ID));
+        assertEquals("existing-value", resultOptions.getHttpHeaders().get("X-Existing-Header"));
+        assertEquals(1, immutableHeaders.size());
+        assertNull(immutableHeaders.get(GigaChatCachingAdvisor.X_SESSION_ID));
     }
 
     private String getSessionId(ChatOptions options) {


### PR DESCRIPTION
## Summary

Fixes `GigaChatCachingAdvisor` so it no longer mutates the `httpHeaders` map stored on `GigaChatOptions` directly. When a session id is present, the advisor now copies any existing headers into a mutable `HashMap`, adds `X-Session-ID`, and writes the copied map back to the options.

This preserves existing headers while avoiding `UnsupportedOperationException` for callers that configured `GigaChatOptions.httpHeaders` with an immutable map such as `Map.of(...)`.

## Testing

Added a focused advisor test covering immutable headers: it verifies the advisor call does not throw, preserves the existing header, adds `X-Session-ID`, and leaves the original immutable map unchanged.

Could not run the Maven test suite in this environment because only a JRE is installed (`javac` and `mvn` are unavailable). `git diff --check` passed.

Closes #117
