### PR TITLE
Add GigaChatModel image generation support

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
@@ -7,18 +7,13 @@ import chat.giga.springai.api.chat.GigaChatApi;
 import chat.giga.springai.api.chat.completion.CompletionRequest;
 import chat.giga.springai.api.chat.completion.CompletionResponse;
 import chat.giga.springai.api.chat.models.ModelDescription;
+import chat.giga.springai.image.GigaChatImageExtractorUtil;
 import chat.giga.springai.tool.definition.GigaToolDefinition;
 import io.micrometer.observation.Observation;
 import io.micrometer.observation.ObservationRegistry;
 import io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.UUID;
+
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
@@ -52,12 +47,14 @@ import org.springframework.ai.model.tool.ToolExecutionResult;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.lang.Nullable;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeTypeUtils;
 import reactor.core.publisher.Flux;
 
 @Slf4j
@@ -522,11 +519,30 @@ public class GigaChatModel implements ChatModel {
                 .content(message.getContent())
                 .toolCalls(toolCalls)
                 .properties(Collections.unmodifiableMap(metadata))
+                .media(extractImageMediaFromTextContent(message.getContent()))
                 .build();
         var generationMetadata = ChatGenerationMetadata.builder()
                 .finishReason(choice.getFinishReason())
                 .build();
         return new Generation(assistantMessage, generationMetadata);
+    }
+
+    private List<Media> extractImageMediaFromTextContent(String content) {
+        List<Media> media = new ArrayList<>();
+
+        if (content != null) {
+            for (String fileId : GigaChatImageExtractorUtil.extract(content)) {
+                byte[] imageBytes = gigaChatApi.downloadFile(fileId);
+                media.add(Media.builder()
+                        .id(fileId)
+                        .mimeType(MimeTypeUtils.IMAGE_JPEG)
+                        .data(new ByteArrayResource(imageBytes))
+                        .build());
+                gigaChatApi.deleteFile(fileId);
+            }
+        }
+
+        return media;
     }
 
     private ChatResponse buildChatResponseWithCustomMetadata(Prompt prompt, ChatResponse originalResponse) {
@@ -558,6 +574,7 @@ public class GigaChatModel implements ChatModel {
                     lastUserMessage.getMedia().stream().map(Media::getId).toList());
         }
 
+        // Если надо добавлять файлы созданные моделью отдельными метаданными, могу добавить здесь
         return chatResponseBuilder.build();
     }
 

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageExtractorUtil.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageExtractorUtil.java
@@ -1,0 +1,25 @@
+package chat.giga.springai.image;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class GigaChatImageExtractorUtil {
+    private static final Pattern IMG_ID_PATTERN = Pattern.compile("<img\\s+src=\"([a-fA-F0-9\\-]{36})\"");
+
+    public static Set<String> extract(String content) {
+        Set<String> fileIds = new HashSet<>();
+
+        if (content != null) {
+            Matcher matcher = IMG_ID_PATTERN.matcher(content);
+
+            while (matcher.find()) {
+                String fileId = matcher.group(1);
+                fileIds.add(fileId);
+            }
+        }
+
+        return fileIds;
+    }
+}

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
@@ -4,12 +4,8 @@ import chat.giga.springai.api.chat.GigaChatApi;
 import chat.giga.springai.api.chat.completion.CompletionRequest;
 import chat.giga.springai.api.chat.completion.CompletionResponse;
 import io.micrometer.observation.ObservationRegistry;
-import java.util.ArrayList;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+
+import java.util.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.image.Image;
 import org.springframework.ai.image.ImageGeneration;
@@ -29,9 +25,7 @@ import org.springframework.util.Assert;
 
 @Slf4j
 public class GigaChatImageModel implements ImageModel {
-
     private static final String FUNCTION_CALL_AUTO = "auto";
-    private static final Pattern IMG_ID_PATTERN = Pattern.compile("<img\\s+src=\"([a-fA-F0-9\\-]{36})\"");
 
     private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION =
             new DefaultImageModelObservationConvention();
@@ -152,13 +146,13 @@ public class GigaChatImageModel implements ImageModel {
 
     private String extractFileId(CompletionResponse response) {
         String content = response.getChoices().get(0).getMessage().getContent();
-        Matcher matcher = IMG_ID_PATTERN.matcher(content);
-        if (!matcher.find()) {
+        Set<String> fileIds = GigaChatImageExtractorUtil.extract(content);
+        if (fileIds.isEmpty()) {
             log.warn("No <img src=\"...\"> tag found in GigaChat response: {}", content);
             return null;
         }
 
-        return matcher.group(1);
+        return fileIds.iterator().next();
     }
 
     private CompletionRequest buildCompletionRequest(ImagePrompt prompt) {

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
@@ -22,12 +22,11 @@ import chat.giga.springai.api.chat.completion.CompletionResponse;
 import chat.giga.springai.api.chat.param.FunctionCallParam;
 import chat.giga.springai.tool.GigaTools;
 import chat.giga.springai.tool.annotation.GigaTool;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+
+import java.util.*;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -41,6 +40,8 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 import org.springframework.ai.chat.messages.AssistantMessage;
 import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.ToolResponseMessage;
@@ -57,6 +58,7 @@ import reactor.core.publisher.Flux;
 import reactor.test.StepVerifier;
 
 @ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
 public class GigaChatModelTest {
     @Mock
     private GigaChatApi gigaChatApi;
@@ -490,5 +492,48 @@ public class GigaChatModelTest {
                                 put(GigaChatModel.UPLOADED_MEDIA_IDS, List.of("5512e5c1-2829-4b44-ad2d-c9bce5f8b154"));
                             }
                         }));
+    }
+
+    @ParameterizedTest
+    @MethodSource("imageExtractionParameters")
+    @DisplayName("Тест проверяет извлечение изображений из ChatResponse")
+    void testImageExtraction(String responseContent, Set<String> expectedMediaIds) {
+        when(gigaChatApi.chatCompletionEntity(any(), any()))
+                .thenReturn(new ResponseEntity<>(this.response, HttpStatusCode.valueOf(200)));
+        when(gigaChatApi.downloadFile(any()))
+                .thenReturn(new byte[] { });
+
+        when(this.response.getChoices())
+                .thenReturn(List.of(new CompletionResponse.Choice()
+                        .setMessage(new CompletionResponse.MessagesRes()
+                                .setContent(responseContent))));
+
+        Prompt prompt = new Prompt(List.of(
+                UserMessage.builder().text("Некий промт").build()));
+        ChatResponse chatResponse = gigaChatModel.call(prompt);
+        List<Media> media = chatResponse.getResult().getOutput().getMedia();
+
+        Set<String> actualMediaIds = Stream.ofNullable(media)
+                .flatMap(Collection::stream)
+                .map(Media::getId)
+                .collect(Collectors.toSet());
+
+        assertEquals(expectedMediaIds, actualMediaIds);
+    }
+
+    public static Stream<Arguments> imageExtractionParameters() {
+        return Stream.of(
+                Arguments.of(
+                        "Привет <img src=\"c2cac967-e8d3-4851-a93c-649e086b1856\" fuse=\"true\"/> также приложил визуализацию текста «Привет».",
+                        Set.of("c2cac967-e8d3-4851-a93c-649e086b1856")
+                ),
+                Arguments.of("Привет <img src=\"e5f8ce06-9742-48b9-b7f4-85e92acea7aa\" fuse=\"true\"/> <img src=\"2011ccb8-b54d-4647-bd34-6b57d5df90cb\" fuse=\"true\"/> Тест",
+                        Set.of("e5f8ce06-9742-48b9-b7f4-85e92acea7aa", "2011ccb8-b54d-4647-bd34-6b57d5df90cb")
+                ),
+                Arguments.of(
+                        "Привет, это проверка без изображений",
+                        Set.of()
+                )
+        );
     }
 }


### PR DESCRIPTION
- Для GigaChatModel возвращаемые изображение кладутся в media-s. Для воспроизведения - выставить function_call=auto
- Если требуется передавать media в отдельном заголовке - могу добавить - оставил временный комментарий в месте, где это может потребоваться. Если не потребуется - комментарий удалю
- Документацию планирую добавить уже после того как PR посмотрят и будет поставлен апрув