### PR TITLE
Прокидываем ошибку, если при вызове gigaChat происходит 4хх или 5хх

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
@@ -190,6 +190,9 @@ public class GigaChatApi {
                 .headers(applyHeaders(headers))
                 .body(Mono.just(chatRequest), CompletionRequest.class)
                 .exchangeToFlux(rs -> {
+                    if (rs.statusCode().isError()) {
+                        return rs.createException().flatMapMany(Flux::error);
+                    }
                     String id = rs.headers().asHttpHeaders().getFirst(X_REQUEST_ID);
                     return rs.bodyToFlux(String.class)
                             .takeUntil(SSE_DONE_PREDICATE)


### PR DESCRIPTION
Обработка HTTP ошибок в WebClient