### PR TITLE
GH-133: форвард-порт #122 — логирование ошибочных ответов сервера авторизации

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/auth/bearer/GigaChatOAuthClient.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/auth/bearer/GigaChatOAuthClient.java
@@ -8,6 +8,7 @@ import chat.giga.springai.api.HttpClientUtils;
 import chat.giga.springai.api.auth.GigaChatApiScope;
 import chat.giga.springai.api.auth.GigaChatAuthProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.UUID;
 import javax.net.ssl.KeyManagerFactory;
@@ -16,11 +17,14 @@ import lombok.extern.slf4j.Slf4j;
 import nl.altindag.ssl.SSLFactory;
 import org.jspecify.annotations.Nullable;
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.util.Assert;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import tools.jackson.databind.DeserializationFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 
 /**
  * HTTP client for GigaChat OAuth 2.0 token endpoint.
@@ -33,6 +37,16 @@ import org.springframework.web.client.RestClient;
  */
 @Slf4j
 public class GigaChatOAuthClient {
+
+    private static final int MAX_LOGGED_BODY_LENGTH = 500;
+
+    // Jackson 3 по умолчанию НЕ падает на неизвестных полях (в отличие от Jackson 2).
+    // Включаем FAIL_ON_UNKNOWN_PROPERTIES, чтобы JSON-тело ошибки авторизации
+    // (например {"code":6,"message":...}) не парсилось молча в пустой токен,
+    // а приводило к RestClientException с телом ответа — как в линии 1.1.x.
+    private static final ObjectMapper DEFAULT_OBJECT_MAPPER = JsonMapper.builder()
+            .enable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+            .build();
 
     /**
      * HTTP Client for OAuth interaction with proper ssl and observability.
@@ -50,6 +64,11 @@ public class GigaChatOAuthClient {
     private final GigaAuthToken authToken;
 
     /**
+     * ObjectMapper for deserializing token response bodies.
+     */
+    private final ObjectMapper objectMapper;
+
+    /**
      * Creates auth client with default RestClient.Builder and SSL configuration.
      *
      * @param apiProperties API configuration including auth URL, timeouts, SSL settings
@@ -60,7 +79,7 @@ public class GigaChatOAuthClient {
             final GigaChatApiProperties apiProperties,
             final RestClient.Builder builder,
             final GigaAuthToken authToken) {
-        this(apiProperties, builder, null, null, authToken);
+        this(apiProperties, builder, null, null, authToken, DEFAULT_OBJECT_MAPPER);
     }
 
     /**
@@ -78,6 +97,26 @@ public class GigaChatOAuthClient {
             @Nullable KeyManagerFactory kmf,
             @Nullable TrustManagerFactory tmf,
             final GigaAuthToken authToken) {
+        this(apiProperties, builder, kmf, tmf, authToken, DEFAULT_OBJECT_MAPPER);
+    }
+
+    /**
+     * Creates auth client with full configuration including custom ObjectMapper.
+     *
+     * @param apiProperties API configuration including auth URL, timeouts, SSL settings
+     * @param builder RestClient.Builder with custom interceptors, filters, or observers
+     * @param kmf custom KeyManagerFactory for client certificates, null to use defaults
+     * @param tmf custom TrustManagerFactory for server validation, null to use defaults
+     * @param authToken token to use for authentication
+     * @param objectMapper ObjectMapper for deserializing token response bodies
+     */
+    public GigaChatOAuthClient(
+            final GigaChatApiProperties apiProperties,
+            final RestClient.Builder builder,
+            @Nullable KeyManagerFactory kmf,
+            @Nullable TrustManagerFactory tmf,
+            final GigaAuthToken authToken,
+            final ObjectMapper objectMapper) {
         GigaChatAuthProperties authProps = apiProperties.getAuth();
         GigaChatInternalProperties internalProps = apiProperties.getInternal();
 
@@ -98,6 +137,7 @@ public class GigaChatOAuthClient {
 
         this.authToken = authToken;
         this.scope = authProps.getScope();
+        this.objectMapper = objectMapper;
     }
 
     /**
@@ -131,15 +171,50 @@ public class GigaChatOAuthClient {
                 .post()
                 .headers(headers -> buildAuthHeaders(headers, this.authToken))
                 .body("scope=" + this.scope)
-                .retrieve()
-                .onStatus(HttpStatusCode::isError, ((request, response) -> {
-                    log.warn(
-                            "Token request returned error status: {}, but attempting to parse response body",
-                            response.getStatusCode());
-                    // Allow parsing response body even on error status
-                    // API may return valid token with 4xx/5xx status
-                }))
-                .body(GigaChatAccessTokenResponse.class);
+                .exchange((request, response) -> {
+                    byte[] bodyBytes = response.getBody().readAllBytes();
+                    String body = new String(bodyBytes, StandardCharsets.UTF_8);
+                    String truncatedBody = truncate(body, MAX_LOGGED_BODY_LENGTH);
+                    String contentType = response.getHeaders().getContentType() != null
+                            ? response.getHeaders().getContentType().toString()
+                            : "unknown";
+
+                    if (response.getStatusCode().isError() && !contentType.contains("json")) {
+                        log.warn(
+                                "Token request failed: status={}, contentType={}, body={}",
+                                response.getStatusCode(),
+                                contentType,
+                                truncatedBody);
+                        throw new RestClientException("Auth endpoint returned non-JSON response (status="
+                                + response.getStatusCode() + ", contentType=" + contentType
+                                + "): " + truncatedBody);
+                    }
+
+                    // Try to parse JSON even for error HTTP response codes (API may return valid token with 4xx/5xx)
+                    try {
+                        return objectMapper.readValue(bodyBytes, GigaChatAccessTokenResponse.class);
+                    } catch (Exception e) {
+                        log.warn(
+                                "Token request failed: status={}, contentType={}, body={}",
+                                response.getStatusCode(),
+                                contentType,
+                                truncatedBody,
+                                e);
+                        throw new RestClientException(
+                                "Auth endpoint returned unparseable JSON (status=" + response.getStatusCode() + "): "
+                                        + truncatedBody,
+                                e);
+                    }
+                });
+    }
+
+    private static String truncate(String text, int maxLength) {
+        // В отличие от 1.1.x, ветки text == null нет: под @NullMarked тело из
+        // new String(bytes, UTF_8) никогда не null.
+        if (text.length() <= maxLength) {
+            return text;
+        }
+        return text.substring(0, maxLength) + "...";
     }
 
     /**

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
@@ -182,6 +182,62 @@ public abstract class GigaChatBearerAuthApiTest {
                 "Exception message should contain response body, but was: " + ex.getMessage());
     }
 
+    @Test
+    @DisplayName("Тест на тело ошибки ровно MAX_LOGGED_BODY_LENGTH (500 символов) — без усечения")
+    void testGetAccessToken_JsonErrorResponse_ExactlyMaxLength_NotTruncated() {
+        // Arrange
+        String jsonBody = jsonErrorBodyOfLength(500);
+        assertEquals(500, jsonBody.length());
+        mockServer.stubFor(post("/api/v2/oauth")
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+
+        // Act & Assert — тело ровно на границе капа, должно попасть в сообщение целиком, без "..."
+        var ex = assertThrows(RestClientException.class, () -> authApi.getValue());
+        assertTrue(
+                ex.getMessage().contains(jsonBody),
+                "Exception message should contain the full 500-char body untruncated, but was: " + ex.getMessage());
+        assertTrue(
+                !ex.getMessage().contains("..."),
+                "Exception message must not be truncated at exactly the cap, but was: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Тест на тело ошибки длиннее MAX_LOGGED_BODY_LENGTH (501 символ) — усечение до 500 + '...'")
+    void testGetAccessToken_JsonErrorResponse_ExceedsMaxLength_Truncated() {
+        // Arrange
+        String jsonBody = jsonErrorBodyOfLength(501);
+        assertEquals(501, jsonBody.length());
+        mockServer.stubFor(post("/api/v2/oauth")
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+
+        // Act & Assert — тело на 1 символ длиннее капа, должно быть усечено ровно до 500 символов + "..."
+        var ex = assertThrows(RestClientException.class, () -> authApi.getValue());
+        String expectedTruncated = jsonBody.substring(0, 500) + "...";
+        assertTrue(
+                ex.getMessage().contains(expectedTruncated),
+                "Exception message should contain exactly the first 500 chars + '...', but was: " + ex.getMessage());
+        assertTrue(
+                !ex.getMessage().contains(jsonBody),
+                "Exception message must not contain the full untruncated 501-char body, but was: " + ex.getMessage());
+    }
+
+    /**
+     * Builds a JSON error body like {@code {"code":6,"message":"AAAA...A"}} padded with
+     * filler characters so the resulting string has exactly {@code totalLength} characters.
+     */
+    private static String jsonErrorBodyOfLength(int totalLength) {
+        String prefix = "{\"code\":6,\"message\":\"";
+        String suffix = "\"}";
+        int fillLength = totalLength - prefix.length() - suffix.length();
+        return prefix + "A".repeat(fillLength) + suffix;
+    }
+
     public static Stream<Arguments> invalidTokenProvider() {
         return Stream.of(
                 Arguments.of(new GigaChatOAuthClient.GigaChatAccessTokenResponse(null, System.currentTimeMillis())),

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
@@ -1,6 +1,7 @@
 package chat.giga.springai.api.auth.bearer;
 
 import static chat.giga.springai.api.chat.GigaChatApi.USER_AGENT_SPRING_AI_GIGACHAT;
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
 import static com.github.tomakehurst.wiremock.client.WireMock.exactly;
@@ -11,6 +12,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import chat.giga.springai.api.GigaChatApiProperties;
 import chat.giga.springai.api.auth.GigaChatApiScope;
@@ -38,6 +40,7 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
 import org.wiremock.spring.ConfigureWireMock;
 import org.wiremock.spring.EnableWireMock;
 import org.wiremock.spring.InjectWireMock;
@@ -132,6 +135,51 @@ public abstract class GigaChatBearerAuthApiTest {
         // Assert
         assertEquals("test-token", accessToken);
         verify(postRequestedFor(urlEqualTo("/api/v2/oauth")));
+    }
+
+    @Test
+    @DisplayName("Тест на ошибку при получении HTML-ответа вместо JSON (502 Bad Gateway)")
+    void testGetAccessToken_HtmlErrorResponse_throwsWithBody() {
+        // Arrange
+        String htmlBody = "<html><body><h1>502 Bad Gateway</h1></body></html>";
+        mockServer.stubFor(post("/api/v2/oauth")
+                .willReturn(aResponse()
+                        .withStatus(502)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.TEXT_HTML_VALUE)
+                        .withBody(htmlBody)));
+
+        // Act & Assert
+        var ex = assertThrows(Exception.class, () -> authApi.getValue());
+        assertTrue(
+                ex.getMessage().contains("non-JSON response"),
+                "Exception message should mention non-JSON response, but was: " + ex.getMessage());
+        assertTrue(
+                ex.getMessage().contains("502"),
+                "Exception message should contain status code, but was: " + ex.getMessage());
+        assertTrue(
+                ex.getMessage().contains("502 Bad Gateway"),
+                "Exception message should contain response body, but was: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName("Тест на ошибку при получении JSON-ответа с невалидными credentials (401)")
+    void testGetAccessToken_JsonErrorResponse_throwsWithNullToken() {
+        // Arrange
+        String jsonBody = "{\"code\":6,\"message\":\"credentials doesn't match db data\"}";
+        mockServer.stubFor(post("/api/v2/oauth")
+                .willReturn(aResponse()
+                        .withStatus(401)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+
+        // Act & Assert — JSON has no access_token, should throw RestClientException
+        var ex = assertThrows(RestClientException.class, () -> authApi.getValue());
+        assertTrue(
+                ex.getMessage().contains("unparseable JSON"),
+                "Exception message should mention unparseable JSON, but was: " + ex.getMessage());
+        assertTrue(
+                ex.getMessage().contains("credentials doesn't match db data"),
+                "Exception message should contain response body, but was: " + ex.getMessage());
     }
 
     public static Stream<Arguments> invalidTokenProvider() {

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/api/auth/bearer/GigaChatBearerAuthApiTest.java
@@ -227,6 +227,47 @@ public abstract class GigaChatBearerAuthApiTest {
                 "Exception message must not contain the full untruncated 501-char body, but was: " + ex.getMessage());
     }
 
+    @Test
+    @DisplayName("Тест-документация: FAIL_ON_UNKNOWN_PROPERTIES действует и на успешный 200 с лишним полем")
+    void testGetAccessToken_SuccessWithUnknownField_throwsUnparseableJson() {
+        // Arrange — валидный токен, но с неизвестным полем: осознанный trade-off включённого
+        // FAIL_ON_UNKNOWN_PROPERTIES (ради детекта error-тел) — новое поле в успешном ответе API сломает парсинг
+        String jsonBody = "{\"access_token\":\"test-token\",\"expires_at\":" + (System.currentTimeMillis() + 3600_000)
+                + ",\"scope\":\"GIGACHAT_API_CORP\"}";
+        mockServer.stubFor(post("/api/v2/oauth")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                        .withBody(jsonBody)));
+
+        // Act & Assert
+        var ex = assertThrows(RestClientException.class, () -> authApi.getValue());
+        assertTrue(
+                ex.getMessage().contains("unparseable JSON"),
+                "Exception message should mention unparseable JSON, but was: " + ex.getMessage());
+    }
+
+    @Test
+    @DisplayName(
+            "Тест-документация: ответ ошибки без заголовка Content-Type трактуется как non-JSON (contentType=unknown)")
+    void testGetAccessToken_ErrorWithoutContentType_throwsNonJsonWithUnknownContentType() {
+        // Arrange — сервер/прокси не прислал Content-Type вообще
+        mockServer.stubFor(
+                post("/api/v2/oauth").willReturn(aResponse().withStatus(400).withBody("Bad Request")));
+
+        // Act & Assert
+        var ex = assertThrows(RestClientException.class, () -> authApi.getValue());
+        assertTrue(
+                ex.getMessage().contains("non-JSON response"),
+                "Exception message should mention non-JSON response, but was: " + ex.getMessage());
+        assertTrue(
+                ex.getMessage().contains("contentType=unknown"),
+                "Exception message should contain contentType=unknown, but was: " + ex.getMessage());
+        assertTrue(
+                ex.getMessage().contains("Bad Request"),
+                "Exception message should contain response body, but was: " + ex.getMessage());
+    }
+
     /**
      * Builds a JSON error body like {@code {"code":6,"message":"AAAA...A"}} padded with
      * filler characters so the resulting string has exactly {@code totalLength} characters.


### PR DESCRIPTION
Closes #133

Форвард-порт f462f24 (#122, линия 1.1.x) на `release/2.x.x`. Base — `release/2.x.x`, т.к. `main` до вливания #132 ещё содержит линию 1.1.x, где этот код уже есть.

## Что портировано

В `GigaChatOAuthClient.requestToken()`: `retrieve().onStatus()` → `exchange()` с чтением тела ответа, логированием (усечение до 500 символов, `MAX_LOGGED_BODY_LENGTH`) и `RestClientException` для non-JSON и непарсящихся JSON-ответов; добавлен конструктор с `ObjectMapper`. Оба теста оригинала (`testGetAccessToken_HtmlErrorResponse`, `testGetAccessToken_JsonErrorResponse`) портированы без изменения логики.

## Осознанные отличия от оригинала

- **Jackson 3** (`tools.jackson`, стек Spring Boot 4) вместо Jackson 2: `FAIL_ON_UNKNOWN_PROPERTIES` в Jackson 3 по умолчанию выключен, поэтому дефолтный маппер собран через `JsonMapper.builder().enable(...)` — иначе JSON-тело ошибки молча парсилось бы в пустой токен (покрыто тестом). Мотив зафиксирован комментарием в коде.
- Убрана мёртвая ветка `text == null` в `truncate()` — пакет `bearer` под `@NullMarked`, `new String(bytes, UTF_8)` не бывает null.
- jspecify `@Nullable` сохранён, откатов миграции нет.

## Доказательства

**До** (baseline `upstream/release/2.x.x`):
- `git grep 'MAX_LOGGED_BODY_LENGTH|non-JSON response|unparseable JSON'` → пусто; тестовых методов нет.
- `mvn -pl spring-ai-gigachat test -Dtest='GigaChatBearerAuthApiTest*'` → Tests run: **14** (7+7), BUILD SUCCESS — функциональности #122 нет.

**После**:
- `mvn -pl spring-ai-gigachat test` → **Tests run: 175, Failures: 0, Errors: 0, Skipped: 0**, BUILD SUCCESS; в обеих конфигурациях auth-теста 7 → **9** (+2 новых).
- `git grep`: `MAX_LOGGED_BODY_LENGTH` (GigaChatOAuthClient.java:41,177), `non-JSON response` (:188), `unparseable JSON` (:204).

**Независимая верификация** (отдельный агент, свой worktree): повторный полный прогон — 175 тестов зелёные, `spotless:check` — ок, посимвольная сверка `git show f462f24` против диффа порта — все функциональные куски на месте.