### PR TITLE
GH-134: форвард-порт #124 — генерация изображений через GigaChatModel

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/GigaChatModel.java
@@ -7,6 +7,7 @@ import chat.giga.springai.api.chat.GigaChatApi;
 import chat.giga.springai.api.chat.completion.CompletionRequest;
 import chat.giga.springai.api.chat.completion.CompletionResponse;
 import chat.giga.springai.api.chat.models.ModelDescription;
+import chat.giga.springai.image.GigaChatImageExtractorUtil;
 import chat.giga.springai.support.GigaRetryTemplate;
 import chat.giga.springai.tool.definition.GigaToolDefinition;
 import io.micrometer.observation.Observation;
@@ -49,11 +50,14 @@ import org.springframework.ai.model.tool.ToolCallingManager;
 import org.springframework.ai.retry.RetryUtils;
 import org.springframework.ai.support.UsageCalculator;
 import org.springframework.ai.tool.definition.ToolDefinition;
+import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.retry.RetryTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.Assert;
 import org.springframework.util.CollectionUtils;
+import org.springframework.util.MimeType;
+import org.springframework.util.MimeTypeUtils;
 import reactor.core.publisher.Flux;
 
 @Slf4j
@@ -63,8 +67,11 @@ public class GigaChatModel implements ChatModel {
             new DefaultChatModelObservationConvention();
     public static final String INTERNAL_CONVERSATION_HISTORY = "GigaChatInternalConversationHistory";
     public static final String UPLOADED_MEDIA_IDS = "GigaChatUploadedMediaIds";
+    public static final String ASSISTANT_MEDIA_IDS = "GigaChatAssistantMediaIds";
     public static final ToolCallingManager DEFAULT_TOOL_CALLING_MANAGER =
             ToolCallingManager.builder().build();
+    // GigaChat всегда возвращает изображения только в формате JPEG
+    public static final MimeType GIGA_CHAT_IMAGE_MIME_TYPE = MimeTypeUtils.IMAGE_JPEG;
 
     /**
      * The lower-level API for the GigaChat service.
@@ -489,15 +496,45 @@ public class GigaChatModel implements ChatModel {
         } else {
             toolCalls = List.of();
         }
+        List<Media> medias = streaming ? List.of() : extractImageMediaFromTextContent(message.getContent());
+
         var assistantMessage = AssistantMessage.builder()
                 .content(message.getContent())
                 .toolCalls(toolCalls)
                 .properties(Collections.unmodifiableMap(metadata))
+                .media(medias)
                 .build();
-        var generationMetadata = ChatGenerationMetadata.builder()
-                .finishReason(choice.getFinishReason())
-                .build();
-        return new Generation(assistantMessage, generationMetadata);
+
+        var generationMetadataBuilder = ChatGenerationMetadata.builder().finishReason(choice.getFinishReason());
+
+        if (!medias.isEmpty()) {
+            generationMetadataBuilder.metadata(
+                    ASSISTANT_MEDIA_IDS, medias.stream().map(Media::getId).toList());
+        }
+
+        return new Generation(assistantMessage, generationMetadataBuilder.build());
+    }
+
+    private List<Media> extractImageMediaFromTextContent(@Nullable String content) {
+        List<Media> media = new ArrayList<>();
+
+        if (content != null) {
+            for (String fileId : GigaChatImageExtractorUtil.extract(content)) {
+                byte[] imageBytes = gigaChatApi.downloadFile(fileId);
+
+                if (imageBytes == null) {
+                    throw new IllegalStateException("Failed to download image for fileId: " + fileId);
+                }
+
+                media.add(Media.builder()
+                        .id(fileId)
+                        .mimeType(GIGA_CHAT_IMAGE_MIME_TYPE)
+                        .data(new ByteArrayResource(imageBytes))
+                        .build());
+            }
+        }
+
+        return media;
     }
 
     private ChatResponse buildChatResponseWithCustomMetadata(Prompt prompt, ChatResponse originalResponse) {

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageExtractorUtil.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageExtractorUtil.java
@@ -1,0 +1,40 @@
+package chat.giga.springai.image;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.jspecify.annotations.Nullable;
+
+public class GigaChatImageExtractorUtil {
+    private static final Pattern IMG_ID_PATTERN = Pattern.compile(
+            "<img\\s+src=\"([a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12})\"");
+
+    private GigaChatImageExtractorUtil() {}
+
+    /**
+     * Извлекает уникальные идентификаторы изображений (UUID) из переданного текстового контента.
+     * <p>
+     * Метод ищет в тексте HTML-теги {@code <img>} с атрибутом {@code src},
+     * значением которого является 36-символьный UUID (например, в формате GigaChat API).
+     * </p>
+     *
+     * @param content исходный текст или HTML-код для анализа; может быть {@code null}
+     * @return {@link List} строк, содержащий все найденные идентификаторы файлов;
+     *         возвращает пустую коллекцию, если совпадений не найдено или {@code content} равен {@code null}
+     */
+    public static List<String> extract(@Nullable String content) {
+        List<String> fileIds = new ArrayList<>();
+
+        if (content != null) {
+            Matcher matcher = IMG_ID_PATTERN.matcher(content);
+
+            while (matcher.find()) {
+                String fileId = matcher.group(1);
+                fileIds.add(fileId);
+            }
+        }
+
+        return fileIds;
+    }
+}

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/image/GigaChatImageModel.java
@@ -9,8 +9,6 @@ import java.util.ArrayList;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.image.Image;
 import org.springframework.ai.image.ImageGeneration;
@@ -49,7 +47,6 @@ import org.springframework.util.Assert;
 public class GigaChatImageModel implements ImageModel {
 
     private static final String FUNCTION_CALL_AUTO = "auto";
-    private static final Pattern IMG_ID_PATTERN = Pattern.compile("<img\\s+src=\"([a-fA-F0-9\\-]{36})\"");
 
     private static final ImageModelObservationConvention DEFAULT_OBSERVATION_CONVENTION =
             new GigaChatImageModelObservationConvention();
@@ -278,13 +275,13 @@ public class GigaChatImageModel implements ImageModel {
             log.warn("GigaChat image response has no content");
             return null;
         }
-        Matcher matcher = IMG_ID_PATTERN.matcher(content);
-        if (!matcher.find()) {
+        List<String> fileIds = GigaChatImageExtractorUtil.extract(content);
+        if (fileIds.isEmpty()) {
             log.warn("No <img src=\"...\"> tag found in GigaChat response: {}", content);
             return null;
         }
 
-        return matcher.group(1);
+        return fileIds.get(0);
     }
 
     /**

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
@@ -23,11 +23,13 @@ import chat.giga.springai.api.chat.completion.CompletionResponse;
 import chat.giga.springai.api.chat.param.FunctionCallParam;
 import chat.giga.springai.tool.GigaTools;
 import chat.giga.springai.tool.annotation.GigaTool;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -607,5 +609,63 @@ public class GigaChatModelTest {
         assertEquals(1.3, capturedRequest.getRepetitionPenalty());
         assertEquals(2.5, capturedRequest.getUpdateInterval());
         assertEquals(true, capturedRequest.getProfanityCheck());
+    }
+
+    @ParameterizedTest
+    @MethodSource("imageExtractionParameters")
+    @DisplayName("Тест проверяет извлечение изображений из ChatResponse")
+    void testImageExtraction(String responseContent, List<String> expectedMediaIds) {
+        when(gigaChatApi.chatCompletionEntity(any(), any()))
+                .thenReturn(new ResponseEntity<>(this.response, HttpStatusCode.valueOf(200)));
+        Mockito.lenient().when(gigaChatApi.downloadFile(any())).thenReturn(new byte[] {});
+
+        when(this.response.getChoices())
+                .thenReturn(List.of(new CompletionResponse.Choice()
+                        .setMessage(new CompletionResponse.MessagesRes().setContent(responseContent))));
+
+        Prompt prompt =
+                new Prompt(List.of(UserMessage.builder().text("Некий промт").build()));
+        ChatResponse chatResponse = gigaChatModel.call(prompt);
+        List<Media> media = chatResponse.getResult().getOutput().getMedia();
+
+        List<String> actualMediaIds = Stream.ofNullable(media)
+                .flatMap(Collection::stream)
+                .map(Media::getId)
+                .collect(Collectors.toList());
+
+        assertEquals(expectedMediaIds, actualMediaIds);
+    }
+
+    public static Stream<Arguments> imageExtractionParameters() {
+        return Stream.of(
+                Arguments.of(
+                        "Привет <img src=\"c2cac967-e8d3-4851-a93c-649e086b1856\" fuse=\"true\"/> также приложил визуализацию текста «Привет».",
+                        List.of("c2cac967-e8d3-4851-a93c-649e086b1856")),
+                Arguments.of(
+                        "Привет <img src=\"e5f8ce06-9742-48b9-b7f4-85e92acea7aa\" fuse=\"true\"/> <img src=\"2011ccb8-b54d-4647-bd34-6b57d5df90cb\" fuse=\"true\"/> Тест",
+                        List.of("e5f8ce06-9742-48b9-b7f4-85e92acea7aa", "2011ccb8-b54d-4647-bd34-6b57d5df90cb")),
+                Arguments.of("Привет, это проверка без изображений", List.of()));
+    }
+
+    @Test
+    @DisplayName("Тест проверяет поведения GigaChatModel при падении gigaChatApi.downloadFile")
+    void testDownloadFileFailure() {
+        when(gigaChatApi.chatCompletionEntity(any(), any()))
+                .thenReturn(new ResponseEntity<>(this.response, HttpStatusCode.valueOf(200)));
+        Mockito.lenient().when(gigaChatApi.downloadFile(any())).thenReturn(null);
+
+        when(this.response.getChoices())
+                .thenReturn(List.of(new CompletionResponse.Choice()
+                        .setMessage(new CompletionResponse.MessagesRes()
+                                .setContent(
+                                        "Привет <img src=\"e5f8ce06-9742-48b9-b7f4-85e92acea7aa\" fuse=\"true\"/>"))));
+
+        Prompt prompt =
+                new Prompt(List.of(UserMessage.builder().text("Некий промт").build()));
+
+        IllegalStateException illegalStateException =
+                assertThrows(IllegalStateException.class, () -> gigaChatModel.call(prompt));
+
+        assertTrue(illegalStateException.getMessage().contains("Failed to download image for fileId"));
     }
 }

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/GigaChatModelTest.java
@@ -668,4 +668,58 @@ public class GigaChatModelTest {
 
         assertTrue(illegalStateException.getMessage().contains("Failed to download image for fileId"));
     }
+
+    @Test
+    @DisplayName("Тест проверяет, что buildGeneration кладёт id скачанных media в метаданные "
+            + "под ключом ASSISTANT_MEDIA_IDS, совпадающий с media.getId()")
+    void testImageExtraction_setsAssistantMediaIdsMetadata() {
+        String mediaId = "e5f8ce06-9742-48b9-b7f4-85e92acea7aa";
+        when(gigaChatApi.chatCompletionEntity(any(), any()))
+                .thenReturn(new ResponseEntity<>(this.response, HttpStatusCode.valueOf(200)));
+        when(gigaChatApi.downloadFile(mediaId)).thenReturn(new byte[] {});
+
+        when(this.response.getChoices())
+                .thenReturn(List.of(new CompletionResponse.Choice()
+                        .setMessage(new CompletionResponse.MessagesRes()
+                                .setContent("Привет <img src=\"" + mediaId + "\" fuse=\"true\"/>"))));
+
+        Prompt prompt = new Prompt(
+                List.of(UserMessage.builder().text("Нарисуй что-нибудь").build()));
+        ChatResponse chatResponse = gigaChatModel.call(prompt);
+
+        List<Media> media = chatResponse.getResult().getOutput().getMedia();
+        assertEquals(1, media.size());
+        assertEquals(mediaId, media.get(0).getId());
+
+        List<String> assistantMediaIds = chatResponse.getResult().getMetadata().get(GigaChatModel.ASSISTANT_MEDIA_IDS);
+        assertEquals(List.of(mediaId), assistantMediaIds);
+        assertEquals(media.get(0).getId(), assistantMediaIds.get(0));
+    }
+
+    @Test
+    @DisplayName("Тест проверяет, что при стриминге media НЕ извлекается и downloadFile НЕ вызывается, "
+            + "даже если агрегированный текст содержит валидный <img src=\"UUID\"/>")
+    void testStream_doesNotExtractMediaOrDownloadFile() {
+        String mediaId = "e5f8ce06-9742-48b9-b7f4-85e92acea7aa";
+        Prompt prompt = new Prompt(List.of(new UserMessage("Нарисуй что-нибудь")));
+
+        var completionResponse = new CompletionResponse()
+                .setId(UUID.randomUUID().toString())
+                .setChoices(List.of(new CompletionResponse.Choice()
+                        .setIndex(0)
+                        .setDelta(new CompletionResponse.MessagesRes()
+                                .setRole(CompletionResponse.Role.assistant)
+                                .setContent("Привет <img src=\"" + mediaId + "\" fuse=\"true\"/>"))));
+
+        Mockito.when(gigaChatApi.chatCompletionStream(any(), any())).thenReturn(Flux.just(completionResponse));
+
+        List<ChatResponse> chatResponses =
+                gigaChatModel.stream(prompt).collectList().block();
+
+        assertNotNull(chatResponses);
+        assertTrue(chatResponses.stream().allMatch(cr -> cr.getResults().stream()
+                .allMatch(g -> g.getOutput().getMedia().isEmpty())));
+
+        verify(gigaChatApi, never()).downloadFile(any());
+    }
 }

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/api/chat/GigaChatApiDownloadFileTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/api/chat/GigaChatApiDownloadFileTest.java
@@ -1,0 +1,80 @@
+package chat.giga.springai.api.chat;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import chat.giga.springai.api.GigaChatApiProperties;
+import chat.giga.springai.api.auth.GigaChatAuthProperties;
+import com.github.tomakehurst.wiremock.WireMockServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.ai.retry.NonTransientAiException;
+
+/**
+ * Юнит на реальный HTTP-контракт GET /files/{fileId}/content (GigaChatApi.downloadFile) —
+ * ранее проверялся только замоканным на уровне GigaChatModel вызовом.
+ */
+class GigaChatApiDownloadFileTest {
+
+    // реальный формат наблюдался в интеграции (pr:136): JPEG, начинается с FF D8 (SOI)
+    private static final byte[] JPEG_FIXTURE = new byte[] {
+        (byte) 0xFF, (byte) 0xD8, (byte) 0xFF, (byte) 0xE0, 0x00, 0x10, 'J', 'F', 'I', 'F', (byte) 0xFF, (byte) 0xD9
+    };
+
+    private WireMockServer server;
+
+    @BeforeEach
+    void start() {
+        server = new WireMockServer(options().dynamicPort());
+        server.start();
+    }
+
+    @AfterEach
+    void stop() {
+        server.stop();
+    }
+
+    @Test
+    @DisplayName("downloadFile: 200 с байтами JPEG возвращает их как есть")
+    void downloadFile_success_returnsBytes() {
+        String fileId = "e5f8ce06-9742-48b9-b7f4-85e92acea7aa";
+        server.stubFor(get(urlEqualTo("/files/" + fileId + "/content"))
+                .willReturn(aResponse().withStatus(200).withBody(JPEG_FIXTURE)));
+
+        GigaChatApi api = new GigaChatApi(properties());
+
+        byte[] result = api.downloadFile(fileId);
+
+        assertArrayEquals(JPEG_FIXTURE, result);
+        server.verify(getRequestedFor(urlEqualTo("/files/" + fileId + "/content"))
+                .withHeader("User-Agent", equalTo(GigaChatApi.USER_AGENT_SPRING_AI_GIGACHAT)));
+    }
+
+    @Test
+    @DisplayName("downloadFile: 404 пробрасывается как исключение, а не молча возвращает null "
+            + "(документирует реальное поведение defaultStatusHandler, вызываемого buildGeneration)")
+    void downloadFile_404_throwsInsteadOfReturningNull() {
+        String fileId = "does-not-exist";
+        server.stubFor(get(urlEqualTo("/files/" + fileId + "/content"))
+                .willReturn(aResponse().withStatus(404).withBody("not found")));
+
+        GigaChatApi api = new GigaChatApi(properties());
+
+        assertThrows(NonTransientAiException.class, () -> api.downloadFile(fileId));
+    }
+
+    private GigaChatApiProperties properties() {
+        return GigaChatApiProperties.builder()
+                .baseUrl("http://localhost:" + server.port())
+                .auth(GigaChatAuthProperties.builder().build())
+                .build();
+    }
+}

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageExtractorUtilTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageExtractorUtilTest.java
@@ -1,0 +1,30 @@
+package chat.giga.springai.image;
+
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class GigaChatImageExtractorUtilTest {
+    @ParameterizedTest
+    @MethodSource("smokeTestParameters")
+    @DisplayName("Тест проверяет извлечение mediaId из ответного сообщения агента")
+    void smokeTest(String responseContent, List<String> expectedMediaIds) {
+        List<String> actualMediaIds = GigaChatImageExtractorUtil.extract(responseContent);
+        Assertions.assertEquals(expectedMediaIds, actualMediaIds);
+    }
+
+    public static Stream<Arguments> smokeTestParameters() {
+        return Stream.of(
+                Arguments.of(
+                        "Привет <img src=\"c2cac967-e8d3-4851-a93c-649e086b1856\" fuse=\"true\"/> также приложил визуализацию текста «Привет».",
+                        List.of("c2cac967-e8d3-4851-a93c-649e086b1856")),
+                Arguments.of(
+                        "Привет <img src=\"e5f8ce06-9742-48b9-b7f4-85e92acea7aa\" fuse=\"true\"/> <img src=\"2011ccb8-b54d-4647-bd34-6b57d5df90cb\" fuse=\"true\"/> Тест",
+                        List.of("e5f8ce06-9742-48b9-b7f4-85e92acea7aa", "2011ccb8-b54d-4647-bd34-6b57d5df90cb")),
+                Arguments.of("Привет, это проверка без изображений", List.of()));
+    }
+}

--- a/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageExtractorUtilTest.java
+++ b/spring-ai-gigachat/src/test/java/chat/giga/springai/image/GigaChatImageExtractorUtilTest.java
@@ -25,6 +25,12 @@ public class GigaChatImageExtractorUtilTest {
                 Arguments.of(
                         "Привет <img src=\"e5f8ce06-9742-48b9-b7f4-85e92acea7aa\" fuse=\"true\"/> <img src=\"2011ccb8-b54d-4647-bd34-6b57d5df90cb\" fuse=\"true\"/> Тест",
                         List.of("e5f8ce06-9742-48b9-b7f4-85e92acea7aa", "2011ccb8-b54d-4647-bd34-6b57d5df90cb")),
-                Arguments.of("Привет, это проверка без изображений", List.of()));
+                Arguments.of("Привет, это проверка без изображений", List.of()),
+                // реальное наблюдение (pr:136): модель эхом вернула плейсхолдер FILE_ID из system-промпта,
+                // не являющийся UUID — строгий regex не должен его матчить, чтобы не пытаться скачать
+                // несуществующий файл 'FILE_ID'
+                Arguments.of(
+                        "Привет <img src=\"c2cac967-e8d3-4851-a93c-649e086b1856\" fuse=\"true\"/> <img src=\"FILE_ID\"/>",
+                        List.of("c2cac967-e8d3-4851-a93c-649e086b1856")));
     }
 }


### PR DESCRIPTION
Closes #134

Форвард-порт 07e4470 (#124, линия 1.1.x) на `release/2.x.x`. Base — `release/2.x.x`, т.к. `main` до вливания #132 ещё содержит линию 1.1.x, где этот код уже есть.

## Что портировано

- Новый `GigaChatImageExtractorUtil` — извлечение UUID изображений из тегов `<img src=...>` (строгий regex 8-4-4-4-12).
- `GigaChatModel.buildGeneration` (non-streaming): извлечение изображений из текста ответа, скачивание через `gigaChatApi.downloadFile`, приложение к `AssistantMessage` как `Media` (JPEG); id дублируются в `ChatGenerationMetadata` под ключом `ASSISTANT_MEDIA_IDS`. Streaming-guard сохранён.
- `GigaChatImageModel` переведён с локального `IMG_ID_PATTERN` на общий util.
- Все 4 теста оригинала портированы (+3 imageExtraction, +1 downloadFileFailure в `GigaChatModelTest`; новый `GigaChatImageExtractorUtilTest`).

## Осознанные отличия от оригинала

- Точка встраивания на 2.x — тот же `buildGeneration`, адаптировано под immutable-билдеры Spring AI 2.0 GA (`AssistantMessage.builder().media(...)`).
- jspecify `@Nullable` на параметрах вместо неаннотированных (правило линии 2.x).
- Убран дублирующий вызов `builder.finishReason(...)` из оригинала (ставился дважды — опечатка).
- В `GigaChatImageModel.extractFileId` сохранён существующий на 2.x null-check с warn-логом; контракт не менялся — существующий `GigaChatImageModelTest` прошёл без правок.

## Доказательства

**До** (baseline `upstream/release/2.x.x`):
- `git grep 'GigaChatImageExtractorUtil|ASSISTANT_MEDIA_IDS|extractImageMediaFromTextContent'` → пусто.
- `mvn -pl spring-ai-gigachat test -Dtest='GigaChatModelTest,GigaChatImageModelTest'` → Tests run: **34** (26+8), BUILD SUCCESS — тестов на извлечение изображений из ChatResponse нет.

**После**:
- `mvn -pl spring-ai-gigachat,spring-ai-autoconfigure-model-gigachat,spring-ai-starter-model-gigachat test` → **Tests run: 178 + 15, Failures: 0, Errors: 0**, все модули BUILD SUCCESS; `GigaChatModelTest` 26 → **30**, `GigaChatImageExtractorUtilTest` — **3** (новый).
- `git grep`: символы появились в GigaChatModel.java:70,499,512,518,522 и GigaChatImageModel.java:278.

**Независимая верификация** (отдельный агент, свой worktree): повторный прогон — 178 тестов зелёные, `spotless:check` — ок, посимвольная сверка `git show 07e4470` против диффа порта — все функциональные куски на месте.