### PR TITLE
GH-138: новый целевой адрес GigaChat API — https://api.giga.chat

### DIFF
--- a/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/multimodality/MultimodalityIT.java
+++ b/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/multimodality/MultimodalityIT.java
@@ -26,7 +26,7 @@ public class MultimodalityIT {
             .withConfiguration(AutoConfigurations.of(GigaChatAutoConfiguration.class))
             .withPropertyValues(GigaChatAuthTestProperties.fromEnv())
             .withPropertyValues(
-                    "spring.ai.gigachat.auth.unsafe-ssl=true", "spring.ai.gigachat.chat.options.model=GigaChat");
+                    "spring.ai.gigachat.auth.unsafe-ssl=true", "spring.ai.gigachat.chat.options.model=GigaChat-2");
 
     @Test
     @DisplayName("Тест проверяет, что доступна мультимодальность модели для вызова на примере vision")

--- a/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/system_prompt_sorting/SystemPromptSortingIT.java
+++ b/spring-ai-autoconfigure-model-gigachat/src/test/java/chat/giga/springai/autoconfigure/system_prompt_sorting/SystemPromptSortingIT.java
@@ -28,7 +28,7 @@ public class SystemPromptSortingIT {
             .withConfiguration(AutoConfigurations.of(GigaChatAutoConfiguration.class))
             .withPropertyValues(GigaChatAuthTestProperties.fromEnv())
             .withPropertyValues(
-                    "spring.ai.gigachat.auth.unsafe-ssl=true", "spring.ai.gigachat.chat.options.model=GigaChat");
+                    "spring.ai.gigachat.auth.unsafe-ssl=true", "spring.ai.gigachat.chat.options.model=GigaChat-2");
 
     @Test
     @DisplayName(

--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
@@ -46,7 +46,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 public class GigaChatApi {
-    public static final String DEFAULT_BASE_URL = "https://gigachat.devices.sberbank.ru/api/v1/";
+    public static final String DEFAULT_BASE_URL = "https://api.giga.chat/v1/";
     public static final String DEFAULT_COMPLETIONS_PATH = "/chat/completions";
     public static final String USER_AGENT_SPRING_AI_GIGACHAT = "Spring-AI-GigaChat";
     public static final String PROVIDER_NAME = "gigachat";


### PR DESCRIPTION
Closes #138

С 17 июля 2026 единый целевой URL для подключения к публичному GigaChat API — `https://api.giga.chat` ([changelog от 16.07.2026](https://developers.sber.ru/docs/ru/gigachat/changelog), [REST API](https://developers.sber.ru/docs/ru/gigachat/api/reference/rest/gigachat-api)).

## Изменения

- `GigaChatApi.DEFAULT_BASE_URL`: `https://gigachat.devices.sberbank.ru/api/v1/` → `https://api.giga.chat/v1/` (на новом домене базовый путь `/v1/`, без префикса `/api`).

Адрес OAuth не меняется (`ngw.devices.sberbank.ru:9443`). Пользователи со старыми подключениями могут вернуть прежний адрес через `spring.ai.gigachat.base-url`.

Аналогичный PR в `release/1.1.x` — отдельно.