### PR TITLE
GH-138: новый целевой адрес GigaChat API — https://api.giga.chat (1.1.x)

### DIFF
--- a/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
+++ b/spring-ai-gigachat/src/main/java/chat/giga/springai/api/chat/GigaChatApi.java
@@ -46,7 +46,7 @@ import reactor.core.publisher.Mono;
 
 @Slf4j
 public class GigaChatApi {
-    public static final String DEFAULT_BASE_URL = "https://gigachat.devices.sberbank.ru/api/v1/";
+    public static final String DEFAULT_BASE_URL = "https://api.giga.chat/v1/";
     public static final String DEFAULT_COMPLETIONS_PATH = "/chat/completions";
     public static final String USER_AGENT_SPRING_AI_GIGACHAT = "Spring-AI-GigaChat";
     public static final String PROVIDER_NAME = "gigachat";


### PR DESCRIPTION
Бэкпорт #139 в `release/1.1.x`. Closes-контекст: #138

С 17 июля 2026 единый целевой URL для подключения к публичному GigaChat API — `https://api.giga.chat` ([changelog от 16.07.2026](https://developers.sber.ru/docs/ru/gigachat/changelog), [REST API](https://developers.sber.ru/docs/ru/gigachat/api/reference/rest/gigachat-api)). Старый адрес для новых подключений не используется и в будущем будет отключён — изменение критично для работоспособности библиотеки, поэтому попадает под правила приёма доработок в `release/1.1.x`.

## Изменения

- `GigaChatApi.DEFAULT_BASE_URL`: `https://gigachat.devices.sberbank.ru/api/v1/` → `https://api.giga.chat/v1/` (на новом домене базовый путь `/v1/`, без префикса `/api`).

Адрес OAuth не меняется (`ngw.devices.sberbank.ru:9443`). Пользователи со старыми подключениями могут вернуть прежний адрес через `spring.ai.gigachat.base-url`.